### PR TITLE
fix: missing json syntax highlighting

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -12,6 +12,7 @@ import tailwindConfig from "./tailwind.config.js";
 
 import "npm:prismjs@1.29.0/components/prism-typescript.js";
 import "npm:prismjs@1.29.0/components/prism-diff.js";
+import "npm:prismjs@1.29.0/components/prism-json.js";
 
 import { full as emoji } from "npm:markdown-it-emoji@3";
 import anchor from "npm:markdown-it-anchor@9";


### PR DESCRIPTION
This PR adds missing highlighting for `.json` files.

Before:
![Screenshot 2024-08-05 at 15 18 35](https://github.com/user-attachments/assets/1a701fad-a95b-41fc-8e6f-2846473c2ef2)

After:

![Screenshot 2024-08-05 at 15 17 55](https://github.com/user-attachments/assets/06024037-c1c6-4ac6-8cd5-59de00f51051)
