### PR TITLE
wip: create a style guide for error messages

### DIFF
--- a/runtime/manual/references/contributing/style_guide.md
+++ b/runtime/manual/references/contributing/style_guide.md
@@ -356,6 +356,75 @@ export function foo(): string {
 }
 ```
 
+### Error Messages
+
+User-facing error messages should be clear, concise, and consistent. Error
+messages should be in sentence case but should not end with a period. Error
+messages should be free of grammatical errors and typos and written in American
+English.
+
+> ⚠️ Note that the error message style guide is a work in progress, and not all
+> the error messages have been updated to conform to the current styles.
+
+Error message styles that should be followed:
+
+1. Messages should start with an upper case:
+
+```
+Bad: cannot parse input
+Good: Cannot parse input
+```
+
+2. Messages should not end with a period:
+
+```
+Bad: Cannot parse input.
+Good: Cannot parse input
+```
+
+3. Message should not use quotes for values:
+
+```
+Bad: Cannot parse input "x"
+Good: Cannot parse input x
+```
+
+4. Message should state the action that lead to the error:
+
+```
+Bad: Invalid input x
+Good: Cannot parse input x
+```
+
+5. Active voice should be used:
+
+```
+Bad: Input x cannot be parsed
+Good: Cannot parse input x
+```
+
+6. Messages should not use contractions:
+
+```
+Bad: Can't parse input x
+Good: Cannot parse input x
+```
+
+7. Messages should use a colon when providing additional information:
+
+```
+Bad: Cannot parse input x. value is empty
+Bad: Cannot parse input x: value is empty
+Good: Cannot parse input x, value is empty
+```
+
+8. Additional information should describe the current state:
+
+```
+Bad: Cannot parse input x, value must not be empty
+Good: Cannot parse input x, value is empty
+```
+
 ### `std`
 
 #### Do not depend on external code.


### PR DESCRIPTION
Creates an initial style guide for user-facing error messages. The guide is based on the style guide from V8.

Two large questions that need to be answered (by a core team member)

1. What should the styles be? These are just suggestions / placeholders, but a core team member should really decide on the styles.
2. Will the existing code-base be updated to conform to a consistent set of styles? This doesn't need to happen all at once, but if there is no appetite to provide consistency across the code-base, then the style guide will provide more harm than good.

https://github.com/denoland/std/issues/5574