### PR TITLE
Adjust sidenav and details colors

### DIFF
--- a/_components/Sidebar.tsx
+++ b/_components/Sidebar.tsx
@@ -65,7 +65,7 @@ function SidebarSection(
 }
 
 const LINK_CLASS =
-  "block px-3 py-1.5 text-[.8125rem] leading-4 font-normal text-gray-500 rounded-md hover:bg-pink-100 current:bg-gray-100 current:text-indigo-600/70 transition-colors duration-200 ease-in-out select-none";
+  "block px-3 py-1.5 text-[.8125rem] leading-4 font-normal text-gray-500 rounded-md hover:bg-blue-50 current:bg-blue-50 current:text-blue-500 transition-colors duration-200 ease-in-out select-none";
 
 function SidebarItem(props: {
   item: string | SidebarDoc_ | SidebarLink_;
@@ -117,7 +117,7 @@ function SidebarCategory(props: {
     <>
       <div
         class={LINK_CLASS + " flex justify-between items-center" +
-          (containsCurrent ? " text-indigo-600/70" : "")}
+          (containsCurrent ? " !text-blue-500" : "")}
         data-accordion-trigger
       >
         {props.item.label}

--- a/_includes/doc.tsx
+++ b/_includes/doc.tsx
@@ -99,7 +99,7 @@ export default function Page(props: Lume.Data, helpers: Lume.Helpers) {
         style={{ scrollbarGutter: "stable" }}
       >
         <main class="mx-auto max-w-screen-xl w-full overflow-x-hidden pt-4 pb-8 flex flex-grow">
-          <div class="flex-grow px-4 sm:px-5 md:px-6 max-w-full lg:max-w-[75%]">
+          <div class="flex-grow px-4 sm:px-5 md:px-8 max-w-full lg:max-w-[75%]">
             <article class="max-w-[66ch]">
               <Breadcrumbs
                 title={props.title!}
@@ -120,7 +120,7 @@ export default function Page(props: Lume.Data, helpers: Lume.Helpers) {
                   </ul>
                 </details>
               )}
-              <div class="markdown-body mt-4 lg:mt-8">
+              <div class="markdown-body mt-4">
                 <h1
                   dangerouslySetInnerHTML={{
                     __html: helpers.md(props.title!, true),

--- a/overrides.css
+++ b/overrides.css
@@ -14,6 +14,10 @@
   @apply md:mt-1 !important;
 }
 
+.ddoc {
+  @apply gap-8 !important;
+}
+
 /* Adjust spacing to account for removed header */
 
 .ddoc .toc .documentNavigation {

--- a/styles.css
+++ b/styles.css
@@ -26,10 +26,14 @@
   }
 
   details {
-    @apply rounded border border-offblack p-8 bg-pink-100;
+    @apply rounded border border-gray-1 py-4 px-4;
 
     &[open] summary {
-      @apply pb-4 mb-4 border-b border-offblack;
+      @apply pb-4 mb-4 border-b border-gray-00;
+    }
+
+    summary::marker {
+      @apply text-gray-2;
     }
   }
 }


### PR DESCRIPTION
<img width="331" alt="Screenshot 2024-08-07 at 9 36 24 AM" src="https://github.com/user-attachments/assets/0c4d501b-f2c3-4322-82f0-9fb192f40271">

<img width="643" alt="Screenshot 2024-08-07 at 9 36 54 AM" src="https://github.com/user-attachments/assets/28a3a7c9-59c7-4230-af5a-029b26f30427">

Two instances of removing light pink from our UI since we've settled into using blue as our primary color until the new dotcom is done.  

Also fixed some nearby minor spacing issues with the docs content body where content was too close to the sidenav at the largest viewport