### PR TITLE
Responsive/a11y improvements

### DIFF
--- a/_includes/doc.tsx
+++ b/_includes/doc.tsx
@@ -136,7 +136,7 @@ export default function Page(props: Lume.Data, helpers: Lume.Helpers) {
               </div>
             </article>
             {parentNavigation && (
-              <nav class="grid gap-8 grid-cols-2 max-w-[66ch] items-center justify-between mt-6">
+              <nav class="grid gap-8 grid-cols-2 max-w-[66ch] items-center justify-between mt-12 mx-auto">
                 <div>
                   {parentNavigation[index! - 1] && (
                     <NavigationButton

--- a/_includes/doc.tsx
+++ b/_includes/doc.tsx
@@ -160,7 +160,7 @@ export default function Page(props: Lume.Data, helpers: Lume.Helpers) {
           </div>
         </main>
         <aside class="hidden lg:block pb-8 pr-8 col-span-2">
-          <div class="py-2 sticky top-4">
+          <div class="py-2 sticky top-4" id="toc">
             <ul class="border-l border-gray-200 py-2 pl-2">
               {(props.toc as TableOfContentsItem_[]).map((item) => (
                 <TableOfContentsItem item={item} />

--- a/_includes/doc.tsx
+++ b/_includes/doc.tsx
@@ -16,7 +16,7 @@ export default function Page(props: Lume.Data, helpers: Lume.Helpers) {
   }
 
   function walk(
-    sidebarItems: SidebarItem[]
+    sidebarItems: SidebarItem[],
   ): [SidebarItem[], number] | undefined {
     for (let i = 0; i < sidebarItems.length; i++) {
       const sidebarItem = sidebarItems[i];
@@ -92,7 +92,8 @@ export default function Page(props: Lume.Data, helpers: Lume.Helpers) {
         class="absolute inset-0 backdrop-brightness-50 z-40 hidden sidebar-open:block sidebar-open:lg:hidden"
         id="sidebar-cover"
         data-open="false"
-      ></div>
+      >
+      </div>
       <div
         class="absolute top-16 bottom-0 left-0 right-0 lg:left-74 overflow-y-auto lg:grid lg:grid-cols-7 lg:gap-8 max-w-screen-2xl mx-auto"
         style={{ scrollbarGutter: "stable" }}
@@ -124,7 +125,8 @@ export default function Page(props: Lume.Data, helpers: Lume.Helpers) {
                   dangerouslySetInnerHTML={{
                     __html: helpers.md(props.title!, true),
                   }}
-                ></h1>
+                >
+                </h1>
                 {props.available_since && (
                   <div class="bg-gray-200 rounded-md text-sm py-3 px-4 mb-4 font-semibold">
                     Available since {props.available_since}
@@ -201,8 +203,9 @@ function NavigationButton(props: {
     item = props.item;
   }
   const directionText = props.direction === "prev" ? "Prev" : "Next";
-  const alignmentClass =
-    props.direction === "prev" ? "items-start" : "items-end";
+  const alignmentClass = props.direction === "prev"
+    ? "items-start"
+    : "items-end";
 
   return (
     <a
@@ -277,7 +280,8 @@ function Breadcrumbs(props: {
                 <path
                   fill="rgba(0,0,0,0.5)"
                   d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"
-                ></path>
+                >
+                </path>
               </svg>
             )}
           </>

--- a/_includes/doc.tsx
+++ b/_includes/doc.tsx
@@ -161,7 +161,7 @@ export default function Page(props: Lume.Data, helpers: Lume.Helpers) {
         </main>
         <aside class="hidden lg:block pb-8 pr-8 col-span-2">
           <div class="py-2 sticky top-4" id="toc">
-            <ul class="border-l border-gray-200 py-2 pl-2">
+            <ul class="border-l border-gray-200 py-2 pl-2 relative">
               {(props.toc as TableOfContentsItem_[]).map((item) => (
                 <TableOfContentsItem item={item} />
               ))}

--- a/_includes/doc.tsx
+++ b/_includes/doc.tsx
@@ -16,7 +16,7 @@ export default function Page(props: Lume.Data, helpers: Lume.Helpers) {
   }
 
   function walk(
-    sidebarItems: SidebarItem[],
+    sidebarItems: SidebarItem[]
   ): [SidebarItem[], number] | undefined {
     for (let i = 0; i < sidebarItems.length; i++) {
       const sidebarItem = sidebarItems[i];
@@ -92,15 +92,14 @@ export default function Page(props: Lume.Data, helpers: Lume.Helpers) {
         class="absolute inset-0 backdrop-brightness-50 z-40 hidden sidebar-open:block sidebar-open:lg:hidden"
         id="sidebar-cover"
         data-open="false"
-      >
-      </div>
+      ></div>
       <div
-        class="absolute top-16 bottom-0 left-0 right-0 lg:left-74 overflow-y-auto"
+        class="absolute top-16 bottom-0 left-0 right-0 lg:left-74 overflow-y-auto lg:grid lg:grid-cols-7 lg:gap-8 max-w-screen-2xl mx-auto"
         style={{ scrollbarGutter: "stable" }}
       >
-        <main class="mx-auto max-w-screen-xl w-full overflow-x-hidden pt-4 pb-8 flex flex-grow">
-          <div class="flex-grow px-4 sm:px-5 md:px-8 max-w-full lg:max-w-[75%]">
-            <article class="max-w-[66ch]">
+        <main class="mx-auto max-w-screen-xl w-full pt-4 pb-8 flex flex-grow lg:col-span-5">
+          <div class="flex-grow px-4 sm:px-5 md:px-6 max-w-full">
+            <article class="max-w-[66ch] mx-auto">
               <Breadcrumbs
                 title={props.title!}
                 sidebar={sidebar}
@@ -125,8 +124,7 @@ export default function Page(props: Lume.Data, helpers: Lume.Helpers) {
                   dangerouslySetInnerHTML={{
                     __html: helpers.md(props.title!, true),
                   }}
-                >
-                </h1>
+                ></h1>
                 {props.available_since && (
                   <div class="bg-gray-200 rounded-md text-sm py-3 px-4 mb-4 font-semibold">
                     Available since {props.available_since}
@@ -158,30 +156,29 @@ export default function Page(props: Lume.Data, helpers: Lume.Helpers) {
               </nav>
             )}
           </div>
-          <div
-            style={{ "flexBasis": "30%" }}
-            class="hidden lg:block sticky flex-shrink-0 flex-grow-0 px-8 pb-8"
-          >
-            <div>
-              <div class="py-2 top-0 ">
-                <ul class="border-l border-gray-200 py-2 pl-2">
-                  {(props.toc as TableOfContentsItem_[]).map((item) => (
-                    <TableOfContentsItem item={item} />
-                  ))}
-                </ul>
-              </div>
-            </div>
-          </div>
         </main>
-        <props.comp.Footer />
+        <aside class="hidden lg:block pb-8 pr-8 col-span-2">
+          <div class="py-2 sticky top-4">
+            <ul class="border-l border-gray-200 py-2 pl-2">
+              {(props.toc as TableOfContentsItem_[]).map((item) => (
+                <TableOfContentsItem item={item} />
+              ))}
+            </ul>
+          </div>
+        </aside>
+        <div class="lg:col-span-full">
+          <props.comp.Footer />
+        </div>
       </div>
     </>
   );
 }
 
-function NavigationButton(
-  props: { item: SidebarItem; search: Searcher; direction: "prev" | "next" },
-) {
+function NavigationButton(props: {
+  item: SidebarItem;
+  search: Searcher;
+  direction: "prev" | "next";
+}) {
   let item: SidebarDoc_ | SidebarLink_;
   if (typeof props.item === "string") {
     const data = props.search.data(props.item)!;
@@ -204,9 +201,8 @@ function NavigationButton(
     item = props.item;
   }
   const directionText = props.direction === "prev" ? "Prev" : "Next";
-  const alignmentClass = props.direction === "prev"
-    ? "items-start"
-    : "items-end";
+  const alignmentClass =
+    props.direction === "prev" ? "items-start" : "items-end";
 
   return (
     <a
@@ -216,24 +212,20 @@ function NavigationButton(
       <span className="text-sm text-gray-2">{directionText}</span>
       <div className="flex flex-row max-w-full items-center text-blue-500 gap-2">
         {props.direction === "prev" && <>&laquo;</>}
-        <span className="font-semibold flex-shrink truncate">
-          {item.label}
-        </span>
+        <span className="font-semibold flex-shrink truncate">{item.label}</span>
         {props.direction === "next" && <>&raquo;</>}
       </div>
     </a>
   );
 }
 
-function Breadcrumbs(
-  props: {
-    title: string;
-    sidebar: Sidebar_;
-    url: string;
-    sectionTitle: string;
-    sectionHref: string;
-  },
-) {
+function Breadcrumbs(props: {
+  title: string;
+  sidebar: Sidebar_;
+  url: string;
+  sectionTitle: string;
+  sectionHref: string;
+}) {
   const crumbs = [];
   outer: for (const section of props.sidebar) {
     for (const item of section.items) {
@@ -275,9 +267,7 @@ function Breadcrumbs(
         </svg>
         {crumbs.map((crumb, i) => (
           <>
-            <li class="px-2.5 py-1.5">
-              {crumb}
-            </li>
+            <li class="px-2.5 py-1.5">{crumb}</li>
             {i < crumbs.length - 1 && (
               <svg
                 class="size-6 rotate-90"
@@ -287,8 +277,7 @@ function Breadcrumbs(
                 <path
                   fill="rgba(0,0,0,0.5)"
                   d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"
-                >
-                </path>
+                ></path>
               </svg>
             )}
           </>

--- a/index.page.tsx
+++ b/index.page.tsx
@@ -233,7 +233,8 @@ export default function () {
                 </h3>
                 <p class="max-w-[75ch]">
                   Deno, Web, and Node API reference documentation, built for the
-                  Deno experience. Explore the APIs available in Deno in the{" "}
+                  Deno experience. Explore the APIs available in Deno in the
+                  {" "}
                   <a
                     href="/api/deno"
                     class="runtime-link underline underline-offset-4"
@@ -457,8 +458,9 @@ function DocsCTA(props: {
   href: string;
   product: "deploy" | "runtime";
 }) {
-  const productClass =
-    props.product === "deploy" ? "deploy-cta" : "runtime-cta";
+  const productClass = props.product === "deploy"
+    ? "deploy-cta"
+    : "runtime-cta";
   return (
     <a href={props.href} className={`docs-cta ${productClass}`}>
       {props.text}{" "}
@@ -476,17 +478,16 @@ function ContentItem(props: {
   link: string;
   product: string;
 }) {
-  const productClass =
-    props.product === "deploy"
-      ? "deploy-link"
-      : props.product === "runtime"
-      ? "runtime-link"
-      : "help-link"; // Default to "help-link" if product is "help"
+  const productClass = props.product === "deploy"
+    ? "deploy-link"
+    : props.product === "runtime"
+    ? "runtime-link"
+    : "help-link"; // Default to "help-link" if product is "help"
 
   return (
     <div>
       <h4 className="text-lg font-semibold mb-1">{props.title}</h4>
-      <p className="mb-3">{props.description} </p>
+      <p className="mb-3">{props.description}</p>
       <a className={`homepage-link ${productClass}`} href={props.link}>
         {props.linktext}{" "}
         <span aria-hidden="true" class="whitespace-pre">
@@ -502,12 +503,11 @@ function LinkList(props: {
   product: string;
   links: { text: string; href: string }[];
 }) {
-  const productClass =
-    props.product === "deploy"
-      ? "deploy-link"
-      : props.product === "runtime"
-      ? "runtime-link"
-      : "help-link";
+  const productClass = props.product === "deploy"
+    ? "deploy-link"
+    : props.product === "runtime"
+    ? "runtime-link"
+    : "help-link";
   return (
     <div>
       <h4 className="text-lg font-semibold mb-1">{props.title}</h4>

--- a/index.page.tsx
+++ b/index.page.tsx
@@ -233,8 +233,7 @@ export default function () {
                 </h3>
                 <p class="max-w-[75ch]">
                   Deno, Web, and Node API reference documentation, built for the
-                  Deno experience. Explore the APIs available in Deno in the
-                  {" "}
+                  Deno experience. Explore the APIs available in Deno in the{" "}
                   <a
                     href="/api/deno"
                     class="runtime-link underline underline-offset-4"
@@ -453,66 +452,62 @@ export default function () {
   );
 }
 
-function DocsCTA(
-  props: { text: string; href: string; product: "deploy" | "runtime" },
-) {
-  const productClass = props.product === "deploy"
-    ? "deploy-cta"
-    : "runtime-cta";
+function DocsCTA(props: {
+  text: string;
+  href: string;
+  product: "deploy" | "runtime";
+}) {
+  const productClass =
+    props.product === "deploy" ? "deploy-cta" : "runtime-cta";
   return (
-    <a
-      href={props.href}
-      className={`docs-cta ${productClass}`}
-    >
-      {props.text} <span aria-hidden="true">-&gt;</span>
+    <a href={props.href} className={`docs-cta ${productClass}`}>
+      {props.text}{" "}
+      <span aria-hidden="true" class="whitespace-pre">
+        -&gt;
+      </span>
     </a>
   );
 }
 
-function ContentItem(
-  props: {
-    title: string;
-    description: string;
-    linktext: string;
-    link: string;
-    product: string;
-  },
-) {
-  const productClass = props.product === "deploy"
-    ? "deploy-link"
-    : props.product === "runtime"
-    ? "runtime-link"
-    : "help-link"; // Default to "help-link" if product is "help"
+function ContentItem(props: {
+  title: string;
+  description: string;
+  linktext: string;
+  link: string;
+  product: string;
+}) {
+  const productClass =
+    props.product === "deploy"
+      ? "deploy-link"
+      : props.product === "runtime"
+      ? "runtime-link"
+      : "help-link"; // Default to "help-link" if product is "help"
 
   return (
     <div>
       <h4 className="text-lg font-semibold mb-1">{props.title}</h4>
-      <p className="mb-3">
-        {props.description}
-        {" "}
-      </p>
-      <a
-        className={`homepage-link ${productClass}`}
-        href={props.link}
-      >
-        {props.linktext} <span aria-hidden="true">-&gt;</span>
+      <p className="mb-3">{props.description} </p>
+      <a className={`homepage-link ${productClass}`} href={props.link}>
+        {props.linktext}{" "}
+        <span aria-hidden="true" class="whitespace-pre">
+          -&gt;
+        </span>
       </a>
     </div>
   );
 }
 
-function LinkList(
-  props: {
-    title: string;
-    product: string;
-    links: { text: string; href: string }[];
-  },
-) {
-  const productClass = props.product === "deploy"
-    ? "deploy-link"
-    : props.product === "runtime"
-    ? "runtime-link"
-    : "help-link";
+function LinkList(props: {
+  title: string;
+  product: string;
+  links: { text: string; href: string }[];
+}) {
+  const productClass =
+    props.product === "deploy"
+      ? "deploy-link"
+      : props.product === "runtime"
+      ? "runtime-link"
+      : "help-link";
   return (
     <div>
       <h4 className="text-lg font-semibold mb-1">{props.title}</h4>

--- a/sidebar.client.ts
+++ b/sidebar.client.ts
@@ -3,8 +3,7 @@ for (const el of document.querySelectorAll("[data-accordion-trigger]")) {
     e.preventDefault();
     const parent = el.parentElement!;
     const content = parent.querySelector("[data-accordion-content]");
-    const hidden = content!.classList
-      .toggle("hidden");
+    const hidden = content!.classList.toggle("hidden");
     el.querySelector("svg")!.style.transform = hidden
       ? "rotate(90deg)"
       : "rotate(180deg)";
@@ -35,3 +34,32 @@ sidebarCover?.addEventListener("click", () => {
   sidebar.dataset.open = "false";
   sidebarCover.dataset.open = "false";
 });
+
+const toc = document.getElementById("toc");
+if (toc !== null) {
+  const headings = document.querySelectorAll(
+    ".markdown-body :where(h2, h3, h4, h5, h6)",
+  );
+
+  const ACTIVE_CSS = "sidebar__current-item";
+  let activeId = "";
+  const observer = new IntersectionObserver(
+    (entries) => {
+      for (let i = 0; i < entries.length; i++) {
+        const entry = entries[i];
+
+        if (entry.isIntersecting) {
+          const id = entry.target.id;
+          toc
+            .querySelector(`a[href="#${activeId}"]`)
+            ?.classList.remove(ACTIVE_CSS);
+          toc.querySelector(`a[href="#${id}"]`)?.classList.add(ACTIVE_CSS);
+          activeId = id;
+        }
+      }
+    },
+    { rootMargin: "0% 0% -70% 0%" },
+  );
+
+  headings.forEach((el) => observer.observe(el));
+}

--- a/styles.css
+++ b/styles.css
@@ -168,6 +168,14 @@ body:not(:has(.ddoc)) {
   }
 }
 
+.sidebar__current-item {
+  @apply text-indigo-600 relative;
+}
+
+.sidebar__current-item::before {
+  @apply content-["•"] absolute -left-[1.45ch] w-[1ch] text-center h-[1em];
+}
+
 .markdown-body .admonition a {
   @apply text-primary underline underline-offset-2;
 }

--- a/styles.css
+++ b/styles.css
@@ -169,11 +169,11 @@ body:not(:has(.ddoc)) {
 }
 
 .sidebar__current-item {
-  @apply text-blue-500 relative;
+  @apply text-blue-500;
 }
 
 .sidebar__current-item::before {
-  @apply content-[""] absolute -left-[0.85em] w-[0.5em] text-center h-[0.7em] top-[0.25em] [clip-path:polygon(0%_0%,100%_50%,0%_100%)] bg-blue-500;
+  @apply content-[""] absolute left-0 w-[0.5em] text-center h-[1.3em] [clip-path:polygon(0%_10%,100%_50%,0%_90%)] bg-gray-200;
 }
 
 .markdown-body .admonition a {

--- a/styles.css
+++ b/styles.css
@@ -111,7 +111,7 @@ body:not(:has(.ddoc)) {
 /* Global docs CTA button style */
 
 .docs-cta {
-  @apply border border-gray-800 text-black bg-gray-500 font-bold inline-block py-3.5 px-4 rounded-md w-max hover:text-inherit hover:no-underline transition-colors duration-200;
+  @apply border text-balance border-gray-800 text-black bg-gray-500 font-bold inline-block py-3.5 px-4 rounded-md w-max hover:text-inherit hover:no-underline transition-colors duration-200;
 }
 
 .runtime-cta {

--- a/styles.css
+++ b/styles.css
@@ -173,7 +173,7 @@ body:not(:has(.ddoc)) {
 }
 
 .sidebar__current-item::before {
-  @apply content-["•"] absolute -left-[1.45ch] w-[1ch] text-center h-[1em];
+  @apply content-[""] absolute -left-[0.85em] w-[0.5em] text-center h-[0.7em] top-[0.25em] [clip-path:polygon(0%_0%,100%_50%,0%_100%)] bg-indigo-600;
 }
 
 .markdown-body .admonition a {

--- a/styles.css
+++ b/styles.css
@@ -169,11 +169,11 @@ body:not(:has(.ddoc)) {
 }
 
 .sidebar__current-item {
-  @apply text-indigo-600 relative;
+  @apply text-blue-500 relative;
 }
 
 .sidebar__current-item::before {
-  @apply content-[""] absolute -left-[0.85em] w-[0.5em] text-center h-[0.7em] top-[0.25em] [clip-path:polygon(0%_0%,100%_50%,0%_100%)] bg-indigo-600;
+  @apply content-[""] absolute -left-[0.85em] w-[0.5em] text-center h-[0.7em] top-[0.25em] [clip-path:polygon(0%_0%,100%_50%,0%_100%)] bg-blue-500;
 }
 
 .markdown-body .admonition a {


### PR DESCRIPTION
- Fixes issue where `->` arrows on the homepage would sometimes break, and improves link text wrapping
- Makes doc sidebar sticky
  - **NOTE**: this required removing `overflow-x-hidden` from the `<main>` element. In my limited testing, this didn't cause any issues, but thorough reviews appreciated
- Moves the right sidebar out of `<main>` and into an `<aside>` element
- Minor CSS adjustments that mostly shouldn't change anything visually but make things a little easier to reason about under the hood (change `flex` to `grid`).

<img width="988" alt="image" src="https://github.com/user-attachments/assets/f73d5145-4d5d-49fd-bb8d-0f4a403edecb">

![CleanShot 2024-08-09 at 10 07 17](https://github.com/user-attachments/assets/7237f21e-5794-4389-98a6-027f8d2685db)
