### PR TITLE
Fix examples sort order

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,10 @@
 {
-	"deno.enable": true,
-	"editor.defaultFormatter": "denoland.vscode-deno",
-	"editor.formatOnSave": true,
-	"editor.formatOnPaste": false,
-	"[typescriptreact]": {
-		"editor.defaultFormatter": "denoland.vscode-deno"
-	},
-	"editor.detectIndentation": true
+  "deno.enable": true,
+  "editor.defaultFormatter": "denoland.vscode-deno",
+  "editor.formatOnSave": true,
+  "editor.formatOnPaste": false,
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  },
+  "editor.detectIndentation": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,10 @@
 {
-  "deno.enable": true
+	"deno.enable": true,
+	"editor.defaultFormatter": "denoland.vscode-deno",
+	"editor.formatOnSave": true,
+	"editor.formatOnPaste": false,
+	"[typescriptreact]": {
+		"editor.defaultFormatter": "denoland.vscode-deno"
+	},
+	"editor.detectIndentation": true
 }

--- a/examples.page.tsx
+++ b/examples.page.tsx
@@ -51,10 +51,9 @@ export default function* (_data: Lume.Data, helpers: Lume.Helpers) {
   });
 
   for (const example of examples) {
-    const contentNoCommentary = example.parsed.files
-      .map((file) => file.snippets.map((snippet) => snippet.code).join("\n"))
-      .join("\n");
-
+    const contentNoCommentary = example.parsed.files.map((file) =>
+      file.snippets.map((snippet) => snippet.code).join("\n")
+    ).join("\n");
     const url =
       `https://github.com/denoland/deno-docs/blob/main/examples/${example.name}${
         example.parsed.files.length > 1 ? "/main" : ""

--- a/examples.page.tsx
+++ b/examples.page.tsx
@@ -55,9 +55,10 @@ export default function* (_data: Lume.Data, helpers: Lume.Helpers) {
       .map((file) => file.snippets.map((snippet) => snippet.code).join("\n"))
       .join("\n");
 
-    const url = `https://github.com/denoland/deno-docs/blob/main/examples/${
-      example.name
-    }${example.parsed.files.length > 1 ? "/main" : ""}`;
+    const url =
+      `https://github.com/denoland/deno-docs/blob/main/examples/${example.name}${
+        example.parsed.files.length > 1 ? "/main" : ""
+      }`;
     const rawUrl = `https://docs.deno.com/examples/${example.name}${
       example.parsed.files.length > 1 ? "/main" : ""
     }`;
@@ -354,7 +355,8 @@ export function CopyButton(props: { text: string }) {
         <path
           fill="currentColor"
           d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"
-        ></path>
+        >
+        </path>
       </svg>
     </button>
   );

--- a/examples.page.tsx
+++ b/examples.page.tsx
@@ -34,9 +34,11 @@ export const sidebar = [
 ];
 
 export default function* (_data: Lume.Data, helpers: Lume.Helpers) {
-  const files = [...walkSync("./examples/", {
-    exts: [".ts"],
-  })];
+  const files = [
+    ...walkSync("./examples/", {
+      exts: [".ts"],
+    }),
+  ];
   const examples = files.map((file) => {
     const content = Deno.readTextFileSync(file.path);
 
@@ -49,14 +51,13 @@ export default function* (_data: Lume.Data, helpers: Lume.Helpers) {
   });
 
   for (const example of examples) {
-    const contentNoCommentary = example.parsed.files.map((file) =>
-      file.snippets.map((snippet) => snippet.code).join("\n")
-    ).join("\n");
+    const contentNoCommentary = example.parsed.files
+      .map((file) => file.snippets.map((snippet) => snippet.code).join("\n"))
+      .join("\n");
 
-    const url =
-      `https://github.com/denoland/deno-docs/blob/main/examples/${example.name}${
-        example.parsed.files.length > 1 ? "/main" : ""
-      }`;
+    const url = `https://github.com/denoland/deno-docs/blob/main/examples/${
+      example.name
+    }${example.parsed.files.length > 1 ? "/main" : ""}`;
     const rawUrl = `https://docs.deno.com/examples/${example.name}${
       example.parsed.files.length > 1 ? "/main" : ""
     }`;
@@ -97,8 +98,9 @@ export default function* (_data: Lume.Data, helpers: Lume.Helpers) {
                 Edit
               </a>
             </div>
-            {example.parsed.description &&
-              <p class="mt-10 mb-6">{example.parsed.description}</p>}
+            {example.parsed.description && (
+              <p class="mt-10 mb-6">{example.parsed.description}</p>
+            )}
             <div class="relative block">
               <CopyButton text={contentNoCommentary} />
             </div>
@@ -129,9 +131,14 @@ export default function* (_data: Lume.Data, helpers: Lume.Helpers) {
                     locally using the Deno CLI:
                   </p>
                   <div class="markdown-body">
-                    <pre className="highlight"><code>{example.parsed.run.startsWith("deno")
-                      ? example.parsed.run.replace("<url>", url)
-                      : "deno run " + example.parsed.run.replace("<url>", rawUrl)}</code></pre>
+                    <pre className="highlight">
+                      <code>
+                        {example.parsed.run.startsWith("deno")
+                          ? example.parsed.run.replace("<url>", url)
+                          : "deno run " +
+                            example.parsed.run.replace("<url>", rawUrl)}
+                      </code>
+                    </pre>
                   </div>
                 </>
               )}
@@ -215,7 +222,7 @@ export default function* (_data: Lume.Data, helpers: Lume.Helpers) {
       return null;
     }
 
-    group.sort((a, b) => a.sortOrder - b.sortOrder);
+    group.sort((a, b) => a.parsed.sortOrder - b.parsed.sortOrder);
 
     return (
       <section
@@ -272,9 +279,9 @@ export default function* (_data: Lume.Data, helpers: Lume.Helpers) {
           </div>
           <div className="w-full flex flex-col px-8 pt-6 mt-20 md:items-center md:justify-center md:flex-row gap-0 md:gap-16 max-w-screen-xl mx-auto mb-24">
             <p className="max-w-prose mx-auto text-center">
-              Need an example that isn't here? Or want to add one of your
-              own?<br /> We welcome contributions!{" "}
-              <br />You can request more examples, or add your own at our{" "}
+              Need an example that isn't here? Or want to add one of your own?
+              <br /> We welcome contributions! <br />
+              You can request more examples, or add your own at our{" "}
               <a
                 href="https://github.com/denoland/deno-docs?tab=readme-ov-file#examples"
                 class="text-primary hover:underline focus:underline"
@@ -321,7 +328,11 @@ function SnippetComponent(props: {
         <div class="-mx-4 h-full sm:mx-0 overflow-scroll sm:overflow-hidden relative gfm-highlight rounded-md">
           {props.snippet.code && (
             <div class="nocopy h-full markdown-body !bg-[var(--color-canvas-subtle)]">
-              <pre class="highlight language-ts"><code dangerouslySetInnerHTML={{ __html: props.snippet.code }}></code></pre>
+              <pre class="highlight language-ts">
+                <code
+                  dangerouslySetInnerHTML={{ __html: props.snippet.code }}
+                ></code>
+              </pre>
             </div>
           )}
         </div>
@@ -343,8 +354,7 @@ export function CopyButton(props: { text: string }) {
         <path
           fill="currentColor"
           d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"
-        >
-        </path>
+        ></path>
       </svg>
     </button>
   );
@@ -366,11 +376,11 @@ export const TAGS = {
 };
 
 export const DIFFICULTIES = {
-  "beginner": {
+  beginner: {
     title: "Beginner",
     description: "No significant prior knowledge is required for this example.",
   },
-  "intermediate": {
+  intermediate: {
     title: "Intermediate",
     description: "Some prior knowledge is needed for this example.",
   },


### PR DESCRIPTION
Fixes the sort order for Examples categories. Also adds some VS code autosave settings so personal "format on save" preferences don't overwrite the docs settings. (As a consequence, there are several `fmt` changes lumped in here, but the sort order thing is the only actual user-facing code change.)