### PR TITLE
Joco/copy btn fix

### DIFF
--- a/copy.client.ts
+++ b/copy.client.ts
@@ -3,13 +3,13 @@ function findParent(el, find) {
     if (find(el)) {
       return el;
     }
-  } while (el = el.parentElement);
+  } while ((el = el.parentElement));
 }
 
 document.addEventListener("click", (e) => {
   const target = findParent(
     e.target,
-    (el) => el instanceof HTMLButtonElement && el.dataset["copy"],
+    (el) => el instanceof HTMLButtonElement && el.dataset["copy"]
   );
   if (target) {
     navigator?.clipboard?.writeText(target.dataset["copy"]);

--- a/copy.client.ts
+++ b/copy.client.ts
@@ -9,7 +9,7 @@ function findParent(el, find) {
 document.addEventListener("click", (e) => {
   const target = findParent(
     e.target,
-    (el) => el instanceof HTMLButtonElement && el.dataset["copy"]
+    (el) => el instanceof HTMLButtonElement && el.dataset["copy"],
   );
   if (target) {
     navigator?.clipboard?.writeText(target.dataset["copy"]);

--- a/copy.client.ts
+++ b/copy.client.ts
@@ -1,17 +1,7 @@
-function findParent(el, find) {
-  do {
-    if (find(el)) {
-      return el;
-    }
-  } while ((el = el.parentElement));
-}
+const copyBtns = document.querySelectorAll("button[data-copy]");
 
-document.addEventListener("click", (e) => {
-  const target = findParent(
-    e.target,
-    (el) => el instanceof HTMLButtonElement && el.dataset["copy"],
-  );
-  if (target) {
-    navigator?.clipboard?.writeText(target.dataset["copy"]);
-  }
+copyBtns.forEach((btn) => {
+  btn.addEventListener("click", () => {
+    navigator?.clipboard?.writeText(btn.getAttribute("data-copy") as string);
+  });
 });

--- a/styles.css
+++ b/styles.css
@@ -95,11 +95,15 @@ body:not(:has(.ddoc)) {
   }
 
   .copyButton {
-    @apply opacity-0 transition-opacity duration-100 absolute top-2 right-2 p-1 rounded;
+    @apply opacity-0 transition-all duration-100 absolute top-2 right-2 p-1 rounded;
 
     &:hover,
     &:focus {
-      @apply opacity-100 bg-gray-300;
+      @apply opacity-100 bg-gray-200;
+    }
+
+    &:active {
+      transform: scale(1.2);
     }
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -89,16 +89,17 @@ body:not(:has(.ddoc)) {
     @apply max-sm:rounded-none !important;
   }
 
-  & pre:has(code.highlight):hover + .copyButton,
-  & pre.highlight:has(code):hover + .copyButton {
-    @apply block;
+  & pre:has(code.highlight):where(:hover, :focus) + .copyButton,
+  & pre.highlight:has(code):where(:hover, :focus) + .copyButton {
+    @apply opacity-100;
   }
 
   .copyButton {
-    @apply hidden absolute top-2 right-2 p-1 rounded;
+    @apply opacity-0 transition-opacity duration-100 absolute top-2 right-2 p-1 rounded;
 
-    &:hover {
-      @apply block bg-gray-300;
+    &:hover,
+    &:focus {
+      @apply opacity-100 bg-gray-300;
     }
   }
 }


### PR DESCRIPTION
Looks like this issue was already fixed, but the `hidden` class is kind of problematic anyway, since it removes the element from the DOM entirely, so now we just switch its opacity instead.