### PR TITLE
Code block styles, fix anchor links, improve search input

### DIFF
--- a/examples.page.tsx
+++ b/examples.page.tsx
@@ -67,7 +67,7 @@ export default function* (_data: Lume.Data, helpers: Lume.Helpers) {
       title: `${example.parsed.title} - Deno by Example`,
       content: (
         <div>
-          <main class="max-w-screen-lg mx-auto p-4">
+          <main class="max-w-screen-lg mx-auto py-4">
             <div class="flex gap-2 items-center">
               <p
                 class="italic m-0 mr-2"

--- a/examples.page.tsx
+++ b/examples.page.tsx
@@ -68,7 +68,6 @@ export default function* (_data: Lume.Data, helpers: Lume.Helpers) {
       content: (
         <div>
           <main id="content" class="max-w-screen-lg mx-auto py-4">
-
             <div class="flex gap-2 items-center">
               <p
                 class="italic m-0 mr-2"

--- a/styles.css
+++ b/styles.css
@@ -159,11 +159,23 @@ body:not(:has(.ddoc)) {
 
 /* Orama search style overrides */
 .searchbutton-module_searchbutton__gg7JJ {
-  @apply w-64 border-gray-00 !important;
+  @apply w-64 border-gray-00 px-3 rounded-md gap-1 !important;
+}
+
+.searchbutton-module_searchbutton__gg7JJ > svg {
+  @apply w-3.5 h-3.5 !important;
 }
 
 .searchbutton-module_searchbutton__keys__qckL6 {
-  @apply border-gray-00 text-gray-1 !important;
+  @apply border-0 py-0.5 text-gray-1 text-sm !important;
+}
+
+.searlchbutton-module_searchbutton__keys__qckL6 > kbd:first-of-type {
+  @apply text-sm !important;
+}
+
+.searchbutton-module_searchbutton__label__TfmnN {
+  @apply text-sm !important;
 }
 
 .searchbox-module_searchbox__TygrP {

--- a/styles.css
+++ b/styles.css
@@ -56,11 +56,14 @@ h1 {
   }
 
   :where(h2, h3, h4, h5, h6) {
+    .header-anchor:hover {
+      text-decoration: underline;
+      text-underline-offset: 4px;
+    }
+
     .anchor-end {
       opacity: 0;
       transition: opacity 0.2s;
-      text-decoration: underline;
-      text-underline-offset: 4px;
       font-weight: normal;
     }
 

--- a/styles.css
+++ b/styles.css
@@ -83,12 +83,16 @@ h1 {
       @apply text-gray-2;
     }
   }
+
+  & pre {
+    @apply border border-gray-200 bg-gray-50;
+  }
 }
 
 body:not(:has(.ddoc)) {
   & pre:has(code.highlight),
   & pre.highlight:has(code) {
-    @apply p-8 max-sm:-mx-4;
+    @apply px-8 py-6 max-sm:-mx-4;
     @apply max-sm:rounded-none !important;
   }
 
@@ -98,21 +102,21 @@ body:not(:has(.ddoc)) {
   }
 
   .copyButton {
-    @apply hidden absolute top-2 right-2 p-1 rounded;
+    @apply hidden absolute top-2 right-2 p-1 border border-transparent rounded;
 
     &:hover {
-      @apply block bg-gray-300;
+      @apply block border-gray-200;
     }
   }
 }
 
 .markdownBlockTitle + div > pre:has(code.highlight) {
-  @apply rounded-t-none;
+  @apply rounded-t-none border-t-0;
 }
 
 .markdownBlockTitle {
   background-color: var(--bgColor-muted, var(--color-canvas-subtle));
-  @apply px-8 py-4 max-sm:-mx-4 sm:rounded-t-md border-b border-gray-000 text-sm font-semibold;
+  @apply px-8 py-3 max-sm:-mx-4 sm:rounded-t-md border border-gray-200 bg-gray-100 text-sm font-semibold;
 }
 
 .markdown-body h2:hover .anchor-end {


### PR DESCRIPTION
Fixes double underline on header anchor links.

Establishes a new code block style (light mode only for now)

And some small style changes to the search input

<img width="689" alt="Screenshot 2024-08-21 at 10 11 37 AM" src="https://github.com/user-attachments/assets/b2f87674-5eec-49b3-8d9d-ebad0f77e5f9">
