### PR TITLE
Add links to Subhosting SDKs

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -116,6 +116,7 @@ server.use(async (req, next, info) => {
   try {
     const url = new URL(req.url, "http://localhost:8000");
     const redirect = REDIRECTS[url.pathname] || REDIRECTS[url.pathname + "/"];
+    console.log(" redirecting");
     if (redirect) {
       res = new Response(null, {
         status: 301,
@@ -134,6 +135,7 @@ server.use(async (req, next, info) => {
     err = e;
     throw e;
   } finally {
+    console.log("sending to ga4");
     ga4(
       req,
       info.remoteAddr,

--- a/server.ts
+++ b/server.ts
@@ -116,7 +116,6 @@ server.use(async (req, next, info) => {
   try {
     const url = new URL(req.url, "http://localhost:8000");
     const redirect = REDIRECTS[url.pathname] || REDIRECTS[url.pathname + "/"];
-    console.log(" redirecting");
     if (redirect) {
       res = new Response(null, {
         status: 301,
@@ -135,7 +134,6 @@ server.use(async (req, next, info) => {
     err = e;
     throw e;
   } finally {
-    console.log("sending to ga4");
     ga4(
       req,
       info.remoteAddr,

--- a/subhosting/manual/index.md
+++ b/subhosting/manual/index.md
@@ -74,3 +74,7 @@ For a complete reference for the REST API used to implement subhosting, you can
 also provides an [OpenAPI specification](https://api.deno.com/v1/openapi.json)
 which can be used with
 [a number of OpenAPI-compatible tools](https://openapi.tools/).
+
+We also offer SDKs in [JavaScript](https://www.npmjs.com/package/subhosting),
+[Python](https://pypi.org/project/subhosting/0.0.1a0/), and
+[Go](https://github.com/denoland/subhosting-go).


### PR DESCRIPTION
A customer contacted Stainless asking for them to generate a JS SDK from the Subhosting API, citing that they did not see a mention of one in our docs.