### PR TITLE
docs: add `--unstable-http`

### DIFF
--- a/runtime/manual/tools/unstable_flags.md
+++ b/runtime/manual/tools/unstable_flags.md
@@ -225,6 +225,13 @@ Enable unstable file system APIs in the `Deno` namespace. These APIs include:
 - [`Deno.funlockSync`](https://deno.land/api?unstable=&s=Deno.funlockSync)
 - [`Deno.umask`](https://deno.land/api?unstable=&s=Deno.umask)
 
+## `--unstable-http`
+
+Enable unstable HTTP APIs in the `Deno` namespace. These APIs include:
+
+- [`Deno.HttpClient`](https://deno.land/api?unstable=&s=Deno.HttpClient)
+- [`Deno.createHttpClient`](https://deno.land/api?unstable=&s=Deno.createHttpClient)
+
 ## `--unstable-net`
 
 Enable unstable net APIs in the `Deno` namespace. These APIs include:


### PR DESCRIPTION
This updates to include `--unstable-http` on the unstable page, which isn't otherwise explained in the docs. (reference: https://github.com/denoland/deno/blob/main/runtime/js/90_deno_ns.js#L293)

