### PR TITLE
fix: migrate to granular `--unstable-*` flag

### DIFF
--- a/examples/cron.ts
+++ b/examples/cron.ts
@@ -2,7 +2,7 @@
  * @title Deno Cron
  * @difficulty intermediate
  * @tags cli, deploy
- * @run --unstable <url>
+ * @run --unstable-kv <url>
  * @resource {https://docs.deno.com/deploy/kv/manual/cron} Deno Cron user guide
  * @resource {https://docs.deno.com/api/deno/~/Deno.cron} Deno Cron Runtime API docs
  * @group Scheduled Tasks

--- a/examples/kv-watch.ts
+++ b/examples/kv-watch.ts
@@ -2,7 +2,7 @@
  * @title Deno KV Watch
  * @difficulty intermediate
  * @tags cli, deploy
- * @run --unstable <url>
+ * @run --unstable-kv <url>
  * @resource {https://docs.deno.com/deploy/kv/manual} Deno KV user guide
  * @resource {https://docs.deno.com/api/deno/~/Deno.Kv} Deno KV Runtime API docs
  * @group Databases

--- a/examples/kv.ts
+++ b/examples/kv.ts
@@ -2,7 +2,7 @@
  * @title Deno KV: Key/Value Database
  * @difficulty intermediate
  * @tags cli, deploy
- * @run --unstable <url>
+ * @run --unstable-kv <url>
  * @resource {https://docs.deno.com/deploy/kv/manual} Deno KV user guide
  * @resource {https://docs.deno.com/api/deno/~/Deno.Kv} Deno KV Runtime API docs
  * @group Databases

--- a/examples/queues.ts
+++ b/examples/queues.ts
@@ -2,7 +2,7 @@
  * @title Deno Queues
  * @difficulty intermediate
  * @tags cli, deploy
- * @run --unstable <url>
+ * @run --unstable-kv <url>
  * @resource {https://docs.deno.com/deploy/kv/manual/queue_overview} Deno Queues user guide
  * @resource {https://docs.deno.com/api/deno/~/Deno.Kv} Deno Queues Runtime API docs
  * @group Scheduled Tasks

--- a/examples/udp-connector.ts
+++ b/examples/udp-connector.ts
@@ -2,7 +2,7 @@
  * @title UDP Connector: Ping
  * @difficulty intermediate
  * @tags cli
- * @run --allow-net --unstable <url>
+ * @run --allow-net --unstable-net <url>
  * @resource {https://docs.deno.com/api/deno/~/Deno.connect} Doc: Deno.connect
  * @resource {/examples/udp-listener} Example: UDP Listener
  * @group Network

--- a/examples/udp-listener.ts
+++ b/examples/udp-listener.ts
@@ -2,7 +2,7 @@
  * @title UDP Listener: Ping
  * @difficulty intermediate
  * @tags cli
- * @run --allow-net --unstable <url>
+ * @run --allow-net --unstable-net <url>
  * @resource {https://docs.deno.com/api/deno/~/Deno.listenDatagram} Doc: Deno.listenDatagram
  * @resource {/examples/udp-connector} Example: UDP Connector
  * @group Network


### PR DESCRIPTION
Update `--unstable` flag on examples page.