### PR TITLE
docs: clarify acceptable use policy on proxy's

### DIFF
--- a/deploy/manual/acceptable-use-policy.md
+++ b/deploy/manual/acceptable-use-policy.md
@@ -15,6 +15,7 @@ to what we consider as "Acceptable Use", and what we do not.
 - ✅ A personal blog
 - ✅ A company website
 - ✅ An e-commerce site
+- ✅ Reverse proxy
 
 ### Not Acceptable Use
 
@@ -22,7 +23,8 @@ to what we consider as "Acceptable Use", and what we do not.
 - ❌ Highly CPU-intensive load (e.g. machine learning)
 - ❌ Media hosting for external sites
 - ❌ Scrapers
-- ❌ Proxy or VPN
+- ❌ Forward proxy
+- ❌ VPN
 
 ## Guidelines
 


### PR DESCRIPTION
Updating the acceptable use policy documentation to clarify the acceptable and unacceptable use of deploy for proxy use cases.