### PR TITLE
Improving breadcrumbs

### DIFF
--- a/_components/Header.tsx
+++ b/_components/Header.tsx
@@ -152,10 +152,10 @@ function HeaderItem({
     <a
       class={`mt-1 ${
         firstItem ? "ml-0" : ""
-      } mx-2.5 px-0.5 text-md hover:text-primary text-nowrap flex items-center ${
+      } mx-1 px-2 text-md hover:text-primary hover:bg-blue-50 hover:rounded text-nowrap flex items-center ${
         activeOn && url.startsWith(activeOn)
-          ? "text-primary border-b-[1.5px] font-semibold border-blue-200"
-          : "border-b-2 border-transparent"
+          ? "text-primary mx-2.5 px-0.5 underline font-semibold underline-offset-[6px] decoration-primary/20"
+          : ""
       } ${hideOnMobile ? "max-lg:!hidden" : ""}`}
       href={href}
     >

--- a/_components/Sidebar.tsx
+++ b/_components/Sidebar.tsx
@@ -12,7 +12,7 @@ export default function Sidebar(
 ) {
   return (
     <nav
-      class="p-2 pr-0 overflow-y-auto"
+      class="p-2 pt-0 pr-0 overflow-y-auto"
       style={{ scrollbarGutter: "stable", scrollbarWidth: "thin" }}
     >
       <ul>

--- a/_includes/doc.tsx
+++ b/_includes/doc.tsx
@@ -282,7 +282,7 @@ function Breadcrumbs(props: {
           <meta itemprop="position" content="1" />
         </li>
         <svg
-          class="size-5 rotate-90"
+          class="size-4 rotate-90"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"
         >
@@ -306,7 +306,7 @@ function Breadcrumbs(props: {
             </li>
             {i < crumbs.length - 1 && (
               <svg
-                class="size-5 rotate-90"
+                class="size-4 rotate-90"
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 24 24"
               >

--- a/_includes/doc.tsx
+++ b/_includes/doc.tsx
@@ -105,7 +105,7 @@ export default function Page(props: Lume.Data, helpers: Lume.Helpers) {
       >
         <main
           id="content"
-          class="mx-auto max-w-screen-xl w-full pt-4 pb-8 flex flex-grow lg:col-span-5"
+          class="mx-auto max-w-screen-xl w-full pt-2 pb-8 flex flex-grow lg:col-span-5"
         >
           <div class="flex-grow px-4 sm:px-5 md:px-6 max-w-full">
             <article class="max-w-[66ch] mx-auto">
@@ -271,7 +271,7 @@ function Breadcrumbs(props: {
         itemtype="https://schema.org/BreadcrumbList"
       >
         <li
-          class="pr-3 py-1.5 underline underline-offset-4 hover:no-underline hover:text-blue-600 transition duration-100"
+          class="-ml-3 px-3 py-1.5 underline underline-offset-4 decoration-gray-300 hover:decoration-blue-950 hover:text-blue-950 hover:underline-medium hover:bg-blue-50 rounded transition duration-100"
           itemprop="itemListElement"
           itemscope
           itemtype="https://schema.org/ListItem"
@@ -282,7 +282,7 @@ function Breadcrumbs(props: {
           <meta itemprop="position" content="1" />
         </li>
         <svg
-          class="size-6 rotate-90"
+          class="size-5 rotate-90"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"
         >
@@ -306,7 +306,7 @@ function Breadcrumbs(props: {
             </li>
             {i < crumbs.length - 1 && (
               <svg
-                class="size-6 rotate-90"
+                class="size-5 rotate-90"
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 24 24"
               >


### PR DESCRIPTION
Changes up the breadcrumb style a little bit to make the underline stand out less and give some better hover to both breadcrumb and main nav.

Switches main nav from box borders to text decoration to make it a bit less bouncy and accommodate background-color hover states

Also resizes the main content area padding a bit to line up side nav items and breadcrumb better.

<img width="787" alt="Screenshot 2024-09-04 at 4 37 55 PM" src="https://github.com/user-attachments/assets/55d505df-d978-42d3-98b6-56a6cb5b2420">

<img width="769" alt="Screenshot 2024-09-04 at 4 37 09 PM" src="https://github.com/user-attachments/assets/3f393765-ecc7-4a82-b260-fbc4287af0ec">

<img width="819" alt="Screenshot 2024-09-04 at 4 37 24 PM" src="https://github.com/user-attachments/assets/96f10e6c-213e-469a-a305-23fc10074254">
