### PR TITLE
adjust header spacing in markdown content

### DIFF
--- a/_includes/doc.tsx
+++ b/_includes/doc.tsx
@@ -264,7 +264,7 @@ function Breadcrumbs(props: {
   crumbs.push(props.title);
 
   return (
-    <nav class="mb-3">
+    <nav class="mb-4">
       <ul
         class="flex flex-wrap text-gray-700 items-center"
         itemscope

--- a/styles.css
+++ b/styles.css
@@ -51,6 +51,31 @@ h1 {
 .markdown-body {
   font-family: inherit;
 
+  /* Override gfm base styles */
+  p {
+    @apply mb-6;
+  }
+
+  pre {
+    @apply mb-6;
+  }
+
+  h1:first-child {
+    @apply mt-0;
+  }
+
+  h2 {
+    @apply mt-12 mb-4;
+  }
+
+  h3 {
+    @apply mt-10 mb-4;
+  }
+
+  h4 {
+    @apply mt-6 mb-4;
+  }
+
   :where(h1, h2, h3) {
     letter-spacing: -0.0125em;
   }


### PR DESCRIPTION
Adjust spacing between headers and paragraphs to be a bit closer to what we had on Docusaurus

New on left
Old on right
<img width="1798" alt="Screenshot 2024-09-05 at 12 11 15 PM" src="https://github.com/user-attachments/assets/b3dc3d64-89d7-4e5f-83d9-f446c29d650f">
