### PR TITLE
Fix: error: Unknown export './assert.ts' for '@std/assert@1.0.3'.

### DIFF
--- a/examples/permissions.ts
+++ b/examples/permissions.ts
@@ -42,7 +42,7 @@ console.log(readStatus.state);
 // In the case that we no longer need a permission, it is also possible
 // to revoke a process's access to that permission. This is useful when
 // a process starts running untrusted code.
-import { assert } from "jsr:@std/assert@1/assert.ts";
+import { assert } from "jsr:@std/assert";
 
 const runStatus = await Deno.permissions.revoke({ name: "run" });
 assert(runStatus.state !== "granted");


### PR DESCRIPTION
I did "Permission Management" example.

I met error. See below. This pull request will fix the error.
Please check it out.

```sh
deno run https://docs.deno.com/examples/permissions.ts
error: Unknown export './assert.ts' for '@std/assert@1.0.3'.
  Package exports:
 * .
 * ./assert
 * ./almost-equals
 * ./array-includes
 * ./equals
 * ./exists
 * ./false
 * ./greater
 * ./greater-or-equal
 * ./instance-of
 * ./is-error
 * ./less
 * ./less-or-equal
 * ./match
 * ./never
 * ./not-equals
 * ./not-instance-of
 * ./not-match
 * ./not-strict-equals
 * ./object-match
 * ./rejects
 * ./strict-equals
 * ./string-includes
 * ./throws
 * ./assertion-error
 * ./equal
 * ./fail
 * ./unimplemented
 * ./unreachable
    at https://docs.deno.com/examples/permissions.ts:45:24
```