### PR TITLE
docs: fix tutorial code block titles

### DIFF
--- a/runtime/tutorials/digital_ocean.md
+++ b/runtime/tutorials/digital_ocean.md
@@ -21,7 +21,7 @@ The pre-requisite for this is:
 To focus on the deployment, our app will simply be a `main.ts` file that returns
 a string as an HTTP response:
 
-```ts
+```ts title="main.ts"
 import { Application } from "https://deno.land/x/oak/mod.ts";
 
 const app = new Application();
@@ -38,7 +38,7 @@ build the Docker image.
 
 In our `Dockerfile`, let's add:
 
-```Dockerfile
+```Dockerfile title="Dockerfile"
 FROM denoland/deno
 
 EXPOSE 8000

--- a/runtime/tutorials/file_server.md
+++ b/runtime/tutorials/file_server.md
@@ -23,42 +23,27 @@ memory.
 
 **Command:** `deno run --allow-read=. --allow-net file_server.ts`
 
-```ts
-// Start listening on port 8080 of localhost.
-const server = Deno.listen({ port: 8080 });
-console.log("File server running on http://localhost:8080/");
-
-for await (const conn of server) {
-  handleHttp(conn).catch(console.error);
-}
-
-async function handleHttp(conn: Deno.Conn) {
-  const httpConn = Deno.serveHttp(conn);
-  for await (const requestEvent of httpConn) {
+```ts title="file_server.ts"
+Deno.serve(
+  { hostname: "localhost", port: 8080 },
+  (request) => {
     // Use the request pathname as filepath
-    const url = new URL(requestEvent.request.url);
+    const url = new URL(request.url);
     const filepath = decodeURIComponent(url.pathname);
 
     // Try opening the file
-    let file;
     try {
-      file = await Deno.open("." + filepath, { read: true });
+      const file = await Deno.open("." + filepath, { read: true });
+
+      // Stream the file as it's read to the response. That way we don't
+      // need to load the full file into memory.
+      return new Response(file.readable);
     } catch {
       // If the file cannot be opened, return a "404 Not Found" response
-      const notFoundResponse = new Response("404 Not Found", { status: 404 });
-      await requestEvent.respondWith(notFoundResponse);
-      continue;
+      return new Response("404 Not Found", { status: 404 });
     }
-
-    // Build a readable stream so the file doesn't have to be fully loaded into
-    // memory while we send it
-    const readableStream = file.readable;
-
-    // Build and send the response
-    const response = new Response(readableStream);
-    await requestEvent.respondWith(response);
-  }
-}
+  },
+);
 ```
 
 ## Using the `std/http` file server
@@ -72,19 +57,21 @@ install the script to the Deno installation root's bin directory, e.g.
 `/home/alice/.deno/bin/file-server`.
 
 ```shell
-deno install --allow-net --allow-read jsr:@std/http@1.0.0-rc.5/file-server
+# Deno 1.x
+deno install --allow-net --allow-read jsr:@std/http@1/file-server
+# Deno 2.x
+deno install --global --allow-net --allow-read jsr:@std/http@1/file-server
 ```
 
 You can now run the script with the simplified script name. Run it:
 
 ```shell
 $ file-server .
-[...]
 Listening on:
-- Local: http://0.0.0.0:4507
+- Local: http://0.0.0.0:8000
 ```
 
-Now go to [http://0.0.0.0:4507/](http://0.0.0.0:4507/) in your web browser to
+Now go to [http://0.0.0.0:8000/](http://0.0.0.0:8000/) in your web browser to
 see your local directory contents.
 
 The complete list of options are available via:
@@ -96,19 +83,30 @@ file-server --help
 Example output:
 
 ```shell
-Deno File Server
-    Serves a local directory in HTTP.
-  INSTALL:
-    deno install --allow-net --allow-read jsr:@std/http@1.0.0-rc.5/file_server
-  USAGE:
-    file_server [path] [options]
-  OPTIONS:
-    -h, --help          Prints help information
-    -p, --port <PORT>   Set port
-    --cors              Enable CORS via the "Access-Control-Allow-Origin" header
-    --host     <HOST>   Hostname (default is 0.0.0.0)
-    -c, --cert <FILE>   TLS certificate file (enables TLS)
-    -k, --key  <FILE>   TLS key file (enables TLS)
-    --no-dir-listing    Disable directory listing
-    All TLS options are required when one is provided.
+Deno File Server 1.0.5
+  Serves a local directory in HTTP.
+
+INSTALL:
+  deno install --allow-net --allow-read --allow-sys jsr:@std/http@1.0.5/file-server
+
+USAGE:
+  file_server [path] [options]
+
+OPTIONS:
+  -h, --help            Prints help information
+  -p, --port <PORT>     Set port (default is 8000)
+  --cors                Enable CORS via the "Access-Control-Allow-Origin" header
+  --host     <HOST>     Hostname (default is 0.0.0.0)
+  -c, --cert <FILE>     TLS certificate file (enables TLS)
+  -k, --key  <FILE>     TLS key file (enables TLS)
+  -H, --header <HEADER> Sets a header on every request.
+                        (e.g. --header "Cache-Control: no-cache")
+                        This option can be specified multiple times.
+  --no-dir-listing      Disable directory listing
+  --no-dotfiles         Do not show dotfiles
+  --no-cors             Disable cross-origin resource sharing
+  -v, --verbose         Print request level logs
+  -V, --version         Print version information
+
+  All TLS options are required when one is provided.
 ```

--- a/runtime/tutorials/file_system_events.md
+++ b/runtime/tutorials/file_system_events.md
@@ -14,10 +14,7 @@ oldUrl:
 
 To poll for file system events in the current directory:
 
-```ts
-/**
- * watcher.ts
- */
+```ts title="watcher.ts"
 const watcher = Deno.watchFs(".");
 for await (const event of watcher) {
   console.log(">>>> event", event);

--- a/runtime/tutorials/google_cloud_run.md
+++ b/runtime/tutorials/google_cloud_run.md
@@ -26,7 +26,7 @@ Pre-requisites:
 To focus on the deployment, our app will simply be a `main.ts` file that returns
 a string as an HTTP response:
 
-```ts
+```ts title="main.ts"
 import { Application } from "https://deno.land/x/oak/mod.ts";
 
 const app = new Application();

--- a/runtime/tutorials/hashbang.md
+++ b/runtime/tutorials/hashbang.md
@@ -20,13 +20,8 @@ _Note: Hashbangs do not work on Windows._
 In this program, we give the context permission to access the environment
 variables and print the Deno installation path.
 
-```ts
+```ts title="hashbang.ts"
 #!/usr/bin/env -S deno run --allow-env
-
-/**
- *  hashbang.ts
- */
-
 const path = Deno.env.get("DENO_INSTALL");
 
 console.log("Deno Install Path:", path);

--- a/runtime/tutorials/hello_world.md
+++ b/runtime/tutorials/hello_world.md
@@ -22,10 +22,7 @@ and the code ensures the name provided is capitalized.
 
 **Command:** `deno run hello-world.js`
 
-```js
-/**
- * hello-world.js
- */
+```js title="hello-world.js"
 function capitalize(word) {
   return word.charAt(0).toUpperCase() + word.slice(1);
 }
@@ -57,10 +54,7 @@ rather than a `*.js` file.
 
 **Command:** `deno run hello-world.ts`
 
-```ts
-/**
- * hello-world.ts
- */
+```ts title="hello-world.ts"
 function capitalize(word: string): string {
   return word.charAt(0).toUpperCase() + word.slice(1);
 }

--- a/runtime/tutorials/kinsta.md
+++ b/runtime/tutorials/kinsta.md
@@ -15,7 +15,7 @@ applications.
 
 To do so, your `package.json` should look like this:
 
-```json
+```json title="package.json"
 {
   "name": "deno app",
   "scripts": {

--- a/runtime/tutorials/os_signals.md
+++ b/runtime/tutorials/os_signals.md
@@ -27,10 +27,7 @@ APIs.
 
 You can use `Deno.addSignalListener()` function for handling OS signals:
 
-```ts
-/**
- * add_signal_listener.ts
- */
+```ts title="add_signal_listener.ts"
 console.log("Press Ctrl-C to trigger a SIGINT signal");
 
 Deno.addSignalListener("SIGINT", () => {
@@ -51,10 +48,7 @@ deno run add_signal_listener.ts
 You can use `Deno.removeSignalListener()` function to unregister previously
 added signal handler.
 
-```ts
-/**
- * signal_listeners.ts
- */
+```ts title="signal_listeners.ts"
 console.log("Press Ctrl-C to trigger a SIGINT signal");
 
 const sigIntHandler = () => {

--- a/runtime/tutorials/read_write_files.md
+++ b/runtime/tutorials/read_write_files.md
@@ -37,10 +37,7 @@ method returns a promise which provides access to the file's text data.
 
 **Command:** `deno run --allow-read read.ts`
 
-```typescript
-/**
- * read.ts
- */
+```typescript title="read.ts"
 const text = await Deno.readTextFile("./people.json");
 
 console.log(text);
@@ -67,10 +64,7 @@ command.
 
 **Command:** `deno run --allow-write write.ts`
 
-```typescript
-/**
- * write.ts
- */
+```typescript title="write.ts"
 await Deno.writeTextFile("./hello.txt", "Hello World!");
 
 console.log("File written to ./hello.txt");
@@ -96,10 +90,7 @@ To execute the code, the `deno run` command needs the write flag.
 
 **Command:** `deno run --allow-write write.ts`
 
-```typescript
-/**
- * write.ts
- */
+```typescript title="write.ts"
 function writeJson(path: string, data: object): string {
   try {
     Deno.writeTextFileSync(path, JSON.stringify(data));

--- a/runtime/tutorials/subprocess.md
+++ b/runtime/tutorials/subprocess.md
@@ -20,11 +20,7 @@ oldUrl:
 This example is the equivalent of running `echo "Hello from Deno!"` from the
 command line.
 
-```ts
-/**
- * subprocess_simple.ts
- */
-
+```ts title="subprocess_simple.ts"
 // define command used to create the subprocess
 const command = new Deno.Command("echo", {
   args: [
@@ -80,11 +76,7 @@ started a subprocess you must use the `"piped"` option.
 
 This example is the equivalent of running `yes &> ./process_output` in bash.
 
-```ts
-/**
- * subprocess_piping_to_file.ts
- */
-
+```ts title="subprocess_piping_to_files.ts"
 import {
   mergeReadableStreams,
 } from "jsr:@std/streams@1.0.0-rc.4/merge-readable-streams";

--- a/runtime/tutorials/tcp_echo.md
+++ b/runtime/tutorials/tcp_echo.md
@@ -19,10 +19,7 @@ oldUrl:
 This is an example of a server which accepts connections on port 8080, and
 returns to the client anything it sends.
 
-```ts
-/**
- * echo_server.ts
- */
+```ts title="echo_server.ts"
 const listener = Deno.listen({ port: 8080 });
 console.log("listening on 0.0.0.0:8080");
 for await (const conn of listener) {

--- a/runtime/tutorials/unix_cat.md
+++ b/runtime/tutorials/unix_cat.md
@@ -1,5 +1,5 @@
 ---
-title: 'An Implementation of the Unix "cat" Program'
+title: 'Writing a Unix "cat" Program'
 oldUrl:
   - /runtime/manual/examples/unix_cat/
 ---
@@ -24,10 +24,7 @@ oldUrl:
 In this program each command-line argument is assumed to be a filename, the file
 is opened, and printed to stdout (e.g. the console).
 
-```ts
-/**
- * cat.ts
- */
+```ts title="cat.ts"
 for (const filename of Deno.args) {
   const file = await Deno.open(filename);
   await file.readable.pipeTo(Deno.stdout.writable, { preventClose: true });
@@ -37,5 +34,5 @@ for (const filename of Deno.args) {
 To run the program:
 
 ```shell
-deno run --allow-read https://deno.land/std@0.190.0/examples/cat.ts /etc/passwd
+deno run --allow-read cat.ts file1 file2
 ```

--- a/runtime/tutorials/word_finder.md
+++ b/runtime/tutorials/word_finder.md
@@ -28,9 +28,7 @@ You can specify a pattern and list of words to customize the HTML content. If a
 pattern is specified then it will show up in the search text box. If the word
 list is specified, then a bulleted list of words will be rendered.
 
-```jsx
-// render.js
-
+```jsx title="render.js"
 export function renderHtml(pattern, words) {
   let searchResultsContent = "";
   if (words.length > 0) {
@@ -99,9 +97,7 @@ We also need a simple search function which scans the dictionary and returns all
 words that match the specified pattern. The function below takes a pattern and
 dictionary and then returns all matched words.
 
-```jsx
-// search.js
-
+```jsx title="search.js"
 export function search(pattern, dictionary) {
   // Create regex pattern that excludes characters already present in word
   let excludeRegex = "";
@@ -141,9 +137,7 @@ HTML template with data and then return the customized HTML back to the viewer.
 We can conveniently rely on the `/usr/share/dict/words` file as our dictionary
 which is a standard file present on most Unix-like operating systems.
 
-```jsx
-// server.js
-
+```jsx title="server.js"
 import { Application, Router } from "https://deno.land/x/oak/mod.ts";
 import { search } from "./search.js";
 import { renderHtml } from "./render.js";


### PR DESCRIPTION
Mostly some formatting changes before doing bigger ones later in a future PR.

- Update `HTTP file server` doc
- Update `cat tutorial`
- Add file titles to code blocks