### PR TITLE
fix: invalid deno status link

### DIFF
--- a/_components/Footer.tsx
+++ b/_components/Footer.tsx
@@ -71,7 +71,7 @@ const data = [
       },
       {
         label: "Deploy System Status",
-        href: "https://www.denostatus.com",
+        href: "https://denostatus.com",
       },
       {
         label: "Deploy Feedback",


### PR DESCRIPTION
`www` doesn't seem to connect to deno status.