### PR TITLE
docs: add `Deno.ListenTlsOptions.certChain` and `Deno.Seeker[Sync]` to "Deno 1.x to 2.x Migration Guide"

### DIFF
--- a/runtime/manual/advanced/migrate_deprecations.md
+++ b/runtime/manual/advanced/migrate_deprecations.md
@@ -152,7 +152,7 @@ See [deno#9795][deno#9795] for details.
 
 ### Deno.Closer
 
-Use [Closer](https://jsr.io/@std/io/doc/types/~/Closer) from the Standard
+Use [`Closer`](https://jsr.io/@std/io/doc/types/~/Closer) from the Standard
 Library instead.
 
 ```diff
@@ -217,9 +217,9 @@ See the [Deno 1.40 blog post][Deno 1.40 blog post] for details.
 
 ### Deno.ConnectTlsOptions.certChain
 
-Use
-[`Deno.TlsCertifiedKeyPem.cert`](https://docs.deno.com/api/deno/~/Deno.TlsCertifiedKeyPem#property_cert)
-instead.
+Use the
+[`cert`](https://docs.deno.com/api/deno/~/Deno.TlsCertifiedKeyPem#property_cert)
+option instead.
 
 ```diff
 const caCert = await Deno.readTextFile("./certs/my_custom_root_CA.pem");
@@ -237,9 +237,9 @@ See [deno#22274](https://github.com/denoland/deno/pull/22274) for details.
 
 ### Deno.ConnectTlsOptions.certFile
 
-Use
-[`Deno.TlsCertifiedKeyPem.cert`](https://docs.deno.com/api/deno/~/Deno.TlsCertifiedKeyPem#property_cert)
-instead.
+Use the
+[`cert`](https://docs.deno.com/api/deno/~/Deno.TlsCertifiedKeyPem#property_cert)
+option instead.
 
 ```diff
 const caCert = await Deno.readTextFile("./certs/my_custom_root_CA.pem");
@@ -257,9 +257,9 @@ See [deno#22274](https://github.com/denoland/deno/pull/22274) for details.
 
 ### Deno.ConnectTlsOptions.privateKey
 
-Use
-[`Deno.TlsCertifiedKeyPem.cert`](https://docs.deno.com/api/deno/~/Deno.TlsCertifiedKeyPem#property_key)
-instead.
+Use the
+[`key`](https://docs.deno.com/api/deno/~/Deno.TlsCertifiedKeyPem#property_key)
+option instead.
 
 ```diff
 const caCert = await Deno.readTextFile("./certs/my_custom_root_CA.pem");
@@ -666,11 +666,26 @@ methods instead.
 
 See the [Deno 1.40 blog post][Deno 1.40 blog post] for details.
 
+### Deno.ListenTlsOptions.certChain
+
+Use the
+[`cert`](https://docs.deno.com/api/deno/~/Deno.ListenTlsOptions#property_cert)
+option instead.
+
+```diff
+using listener = Deno.listenTls({
+  port: 443,
+- certChain: Deno.readTextFile("./server.crt"),
++ cert: Deno.readTextFile("./server.crt"),
+  key: Deno.readTextFileSync("./server.key"),
+});
+```
+
 ### Deno.ListenTlsOptions.certFile
 
-Pass the certificate file contents to
-[`Deno.ListenTlsOptions.cert`](https://docs.deno.com/api/deno/~/Deno.ListenTlsOptions#property_cert)
-instead.
+Pass the certificate file contents to the
+[`cert`](https://docs.deno.com/api/deno/~/Deno.ListenTlsOptions#property_cert)
+option instead.
 
 ```diff
 using listener = Deno.listenTls({
@@ -685,9 +700,9 @@ See [deno#12639](https://github.com/denoland/deno/issues/12639) for details.
 
 ### Deno.ListenTlsOptions.keyFile
 
-Pass the key file contents to
-[`Deno.ListenTlsOptions.key`](https://docs.deno.com/api/deno/~/Deno.ListenTlsOptions#property_key)
-instead.
+Pass the key file contents to the
+[`key`](https://docs.deno.com/api/deno/~/Deno.ListenTlsOptions#property_key)
+option instead.
 
 ```diff
 using listener = Deno.listenTls({
@@ -870,6 +885,34 @@ directive.
 ```
 
 See [deno#16516](https://github.com/denoland/deno/pull/16516) for details.
+
+### Deno.Seeker
+
+Use [`Seeker`](https://jsr.io/@std/io/doc/types/~/Seeker) from the Standard
+Library instead.
+
+```diff
++ import type { Seeker } from "jsr:@std/io/types";
+
+- function foo(seeker: Deno.Seeker) {
++ function foo(seeker: Seeker) {
+  // ...  
+}
+```
+
+### Deno.SeekerSync
+
+Use [`SeekerSync`](https://jsr.io/@std/io/doc/types/~/SeekerSync) from the
+Standard Library instead.
+
+```diff
++ import type { SeekerSync } from "jsr:@std/io/types";
+
+- function foo(seeker: Deno.SeekerSync) {
++ function foo(seeker: SeekerSync) {
+  // ...  
+}
+```
 
 ### Deno.seekSync()
 


### PR DESCRIPTION
And other small improvements.