### PR TITLE
fix: infinite redirect

### DIFF
--- a/runtime/manual/help.md
+++ b/runtime/manual/help.md
@@ -1,6 +1,5 @@
 ---
 title: "Where To Get Help"
-oldUrl: /runtime/manual/help/
 ---
 
 Stuck? Lost? Get Help from the Community.


### PR DESCRIPTION
The `oldUrl` referred to itself which caused an infinite redirect.