### PR TITLE
fix: broken redirects

### DIFF
--- a/deploy/api/index.md
+++ b/deploy/api/index.md
@@ -4,6 +4,7 @@ sidebar_title: "Overview"
 pagination_next: /deploy/api/runtime-broadcast-channel
 oldUrl:
   - /deploy/docs/runtime-api/
+  - /deploy/manual/runtime-api/
 ---
 
 This is a reference for runtime APIs available on Deno Deploy. This API is very

--- a/deploy/api/runtime-broadcast-channel.md
+++ b/deploy/api/runtime-broadcast-channel.md
@@ -2,6 +2,7 @@
 title: "BroadcastChannel"
 oldUrl:
   - /deploy/docs/runtime-broadcast-channel/
+  - /deploy/manual/runtime-broadcast-channel
 ---
 
 In Deno Deploy, code is run in different data centers around the world in order

--- a/deploy/api/runtime-fs.md
+++ b/deploy/api/runtime-fs.md
@@ -2,6 +2,7 @@
 title: "File system APIs"
 oldUrl:
   - /deploy/docs/runtime-fs/
+  - /deploy/manual/runtime-fs/
 ---
 
 Deno Deploy supports a limited set of the file system APIs available in Deno.

--- a/deploy/api/runtime-node.md
+++ b/deploy/api/runtime-node.md
@@ -2,6 +2,7 @@
 title: "Node.js built-in APIs"
 oldUrl:
   - /deploy/docs/runtime-node/
+  - /deploy/manual/runtime-node/
 ---
 
 Deno Deploy natively supports importing built-in Node.js modules like `fs`,

--- a/deploy/manual/ci_github.md
+++ b/deploy/manual/ci_github.md
@@ -1,5 +1,7 @@
 ---
 title: "CI and GitHub Actions"
+oldUrl:
+ - /deploy/docs/project/
 ---
 
 Deno Deploy's Git integration enables deployment of code changes that are pushed

--- a/deploy/manual/index.md
+++ b/deploy/manual/index.md
@@ -3,6 +3,7 @@ title: "Deploy Quick Start"
 oldUrl:
   - /deploy/
   - /deploy/docs/
+  - /deploy/manual/hello-world/
 ---
 
 Deno Deploy is a globally distributed platform for serverless JavaScript

--- a/deploy/tutorials/tutorial-postgres.md
+++ b/deploy/tutorials/tutorial-postgres.md
@@ -2,6 +2,7 @@
 title: "API server with Postgres"
 oldUrl:
   - /deploy/docs/tutorial-postgres/
+  - /deploy/manual/tutorial-postgres/
 ---
 
 Postgres is a popular database for web applications because of its flexibility

--- a/deploy/tutorials/vite.md
+++ b/deploy/tutorials/vite.md
@@ -2,6 +2,7 @@
 title: "Deploy a React app with Vite"
 oldUrl:
   - /deploy/docs/vite/
+  - /deploy/manual/vite
 ---
 
 This tutorial covers how to deploy a Vite Deno and React app on Deno Deploy.

--- a/runtime/fundamentals/modules.md
+++ b/runtime/fundamentals/modules.md
@@ -15,6 +15,7 @@ oldUrl:
   - /runtime/manual/linking_to_external_code
   - /runtime/manual/linking_to_external_code/reloading_modules
   - /runtime/fundamentals/esm.sh
+  - /runtime/manual/basics/import_maps/
 ---
 
 Deno uses

--- a/runtime/fundamentals/testing.md
+++ b/runtime/fundamentals/testing.md
@@ -11,6 +11,7 @@ oldUrl:
   - /runtime/manual/basics/testing/sanitizers/
   - /runtime/manual/basics/testing/snapshot_testing/
   - /runtime/manual/testing
+  - /runtime/manual/basics/testing/documentation/
 ---
 
 Deno provides a built-in test runner for writing and running tests in both

--- a/runtime/reference/deploying_and_embedding.md
+++ b/runtime/reference/deploying_and_embedding.md
@@ -1,6 +1,6 @@
 ---
 title: "Deploying and embedding Deno"
-old_url:
+oldUrl:
 - /runtime/manual/advanced/embedding_deno/
 - /runtime/manual/advanced/deploying_deno/
 ---

--- a/runtime/tutorials/how_to_with_npm/apollo.md
+++ b/runtime/tutorials/how_to_with_npm/apollo.md
@@ -2,6 +2,7 @@
 title: "How to use Apollo with Deno"
 oldUrl:
   - /runtime/manual/examples/how_to_with_npm/apollo/
+  - /runtime/manual/node/how_to_with_npm/apollo/
 ---
 
 [Apollo Server](https://www.apollographql.com/) is a GraphQL server that you can

--- a/runtime/tutorials/how_to_with_npm/express.md
+++ b/runtime/tutorials/how_to_with_npm/express.md
@@ -2,6 +2,7 @@
 title: "How to use Express with Deno"
 oldUrl:
   - /runtime/manual/examples/how_to_with_npm/express/
+  - /runtime/manual/node/how_to_with_npm/express/
 ---
 
 [Express](https://expressjs.com/) is a popular web framework known for being

--- a/subhosting/manual/quick_start.md
+++ b/subhosting/manual/quick_start.md
@@ -1,5 +1,7 @@
 ---
 title: Subhosting Quick Start
+oldUrl:
+- /deploy/manual/subhosting/projects_and_deployments/
 ---
 
 Looking for the smallest possible example that shows how to deploy code to


### PR DESCRIPTION
The wrong property name was used in the front matter which lead to the redirects not being picked up. Rest is the usual missing 404s