### PR TITLE
fix: missing closing curly brace for CSS block

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -358,6 +358,7 @@ body:not(:has(.ddoc)) {
   background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="%23ef4444" class="size-6"><path stroke-linecap="round" stroke-linejoin="round" d="m9.75 9.75 4.5 4.5m0-4.5-4.5 4.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" /></svg>');
   background-size: contain;
   background-repeat: no-repeat;
+}
 
 .markdown-body > pre.snippet-code[data-example-position="first"] {
   @apply md:border-t md:border-b-0 md:pt-4 rounded-t h-full md:rounded-b-none;


### PR DESCRIPTION
Noticed that our CSS file has a syntax error. This error was introduced in https://github.com/denoland/docs/pull/843