### PR TITLE
chore: run build on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,3 +12,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v1
       - run: deno fmt --check
+      - run: deno task build


### PR DESCRIPTION
Run the `build` task also on CI which would've caught the syntax error found in https://github.com/denoland/docs/pull/848 that was introduced by https://github.com/denoland/docs/pull/843