### PR TITLE
docs: modify docs on doc testing to reflect code snippet execution

### DIFF
--- a/runtime/fundamentals/testing.md
+++ b/runtime/fundamentals/testing.md
@@ -440,6 +440,23 @@ Deno.test("example.ts$4-10.ts", async () => {
 });
 ```
 
+### Skipping code blocks
+
+You can skip the evaluation of code blocks by adding the `ignore` attribute.
+
+````ts
+/**
+ * This code block will not be run.
+ *
+ * ```ts ignore
+ * await sendEmail("deno@example.com");
+ * ```
+ */
+export async function sendEmail(to: string) {
+  // send an email to the given address...
+}
+````
+
 ## Sanitizers
 
 The test runner offers several sanitizers to ensure that the test behaves in a

--- a/runtime/fundamentals/testing.md
+++ b/runtime/fundamentals/testing.md
@@ -399,11 +399,11 @@ markdown) instead.
 
 ### Exported items are automatically imported
 
-Looking at the generated test code above carefully, you will notice that it
-includes the `import` statement to import the `add` fucntion even though the
-original code block does not have it. Briefly, all items imported from the
-module being documented are automatically imported into the generated test code
-with the same name.
+Looking at the generated test code above, you will notice that it includes the
+`import` statement to import the `add` function even though the original code
+block does not have it. When documenting a module, any items exported from the
+module are automatically included in the generated test code using the same
+name.
 
 Let's say we have the following module:
 

--- a/runtime/fundamentals/testing.md
+++ b/runtime/fundamentals/testing.md
@@ -379,7 +379,7 @@ that looks like below:
 import { assertEquals } from "jsr:@std/assert/equals";
 import { add } from "file:///path/to/example.ts";
 
-Deno.test("example.ts$4-10", async () => {
+Deno.test("example.ts$4-10.ts", async () => {
   const sum = add(1, 2);
   assertEquals(sum, 3);
 });
@@ -434,7 +434,7 @@ This will get converted to the following test case:
 import { assertEquals } from "jsr:@std/assert/equals";
 import { add, ONE }, getTwo from "file:///path/to/example.ts";
 
-Deno.test("example.ts$4-10", async () => {
+Deno.test("example.ts$4-10.ts", async () => {
   const sum = add(ONE, getTwo());
   assertEquals(sum, 3);
 });

--- a/runtime/fundamentals/typescript.md
+++ b/runtime/fundamentals/typescript.md
@@ -38,6 +38,10 @@ Deno allows you to type-check your code (without executing it) with the
 deno check module.ts
 # or also type check remote modules and npm packages
 deno check --all module.ts
+# code snippets written in JSDoc can also be type checked
+deno check --doc module.ts
+# or type check code snippets in markdown files
+deno check --doc-only markdown.md
 ```
 
 :::note

--- a/runtime/reference/cli/check.md
+++ b/runtime/reference/cli/check.md
@@ -12,10 +12,11 @@ Type-check a program without execution.
 ## Synopsis
 
 ```bash
-deno check [--import-map <FILE>] [--no-remote] [-q|--quiet] [--no-npm] 
+deno check [--import-map <FILE>] [--no-remote] [-q|--quiet] [--no-npm]
 [--node-modules-dir[=<node-modules-dir>]] [--vendor[=<vendor>]]
 [-c|--config <FILE>] [--no-config] [-r|--reload[=<CACHE_BLOCKLIST>...]]
-[--lock [<FILE>]] [--lock-write] [--no-lock] [--cert <FILE>] [--all] <FILE>
+[--lock [<FILE>]] [--lock-write] [--no-lock] [--cert <FILE>]
+[--doc] [--doc-only] [--all] <FILE>
 
 deno check -h|--help
 ```
@@ -111,6 +112,16 @@ The module entrypoint can be a local file or a remote URL.
 
   Load the certificate from a
   [PEM encoded file](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail)
+
+- `--doc`
+
+  Type-check code blocks in JSDoc as well as actual code. At most one of `--doc`
+  or `--doc-only` can be specified.
+
+- `--doc-only`
+
+  Type-check code blocks in JSDoc and Markdown only. At most one of `--doc` or
+  `--doc-only` can be specified.
 
 - `--all` Type-check all code, including remote modules and npm packages
 

--- a/runtime/reference/cli/test.md
+++ b/runtime/reference/cli/test.md
@@ -164,7 +164,7 @@ Arguments passed to script files
   impacts test execution time.
 
 - `--doc`\
-  Type-check code blocks in JSDoc and Markdown
+  Evaluate code blocks in JSDoc and Markdown
 
 - `--fail-fast[=<N>]`\
   Stop after N errors. Defaults to stopping after first failure.


### PR DESCRIPTION
We landed "true" doc testing in https://github.com/denoland/deno/pull/25220. With this change, `deno test --doc` will actually _run_ code snippets written in JSDoc or markdown files, as well as type checking. This commit updates the corresponding doc pages to follow this change.

Preview of the updated pages:

- https://deno-docs--magurotuna-improved-doc-te.deno.dev/runtime/fundamentals/testing/#documentation-tests
- https://deno-docs--magurotuna-improved-doc-te.deno.dev/runtime/fundamentals/typescript/#type-checking
- https://deno-docs--magurotuna-improved-doc-te.deno.dev/runtime/reference/cli/check/
- https://deno-docs--magurotuna-improved-doc-te.deno.dev/runtime/reference/cli/test/