### PR TITLE
docs(static-site): working example

### DIFF
--- a/deploy/tutorials/static-site.md
+++ b/deploy/tutorials/static-site.md
@@ -39,7 +39,7 @@ You have now a html page that says "Hello" and has a logo.
 To deploy this repo on Deno Deploy, from the `static-site` repository, run:
 
 ```console
-deployctl deploy --project=<your-preferred-project-name> jsr:@std/http@1.0.0-rc.5/file-server
+deployctl deploy --project=<your-preferred-project-name> https://jsr.io/@std/http/1.0.6/file_server.ts
 ```
 
 To give a little more explanation of these commands: Because this is a static

--- a/deploy/tutorials/static-site.md
+++ b/deploy/tutorials/static-site.md
@@ -39,7 +39,7 @@ You have now a html page that says "Hello" and has a logo.
 To deploy this repo on Deno Deploy, from the `static-site` repository, run:
 
 ```console
-deployctl deploy --project=<your-preferred-project-name> https://jsr.io/@std/http/1.0.0-rc.5/file_server.ts
+deployctl deploy --project=<your-preferred-project-name> https://jsr.io/@std/http/1.0.7/file_server.ts
 ```
 
 To give a little more explanation of these commands: Because this is a static

--- a/deploy/tutorials/static-site.md
+++ b/deploy/tutorials/static-site.md
@@ -39,7 +39,7 @@ You have now a html page that says "Hello" and has a logo.
 To deploy this repo on Deno Deploy, from the `static-site` repository, run:
 
 ```console
-deployctl deploy --project=<your-preferred-project-name> https://jsr.io/@std/http/1.0.6/file_server.ts
+deployctl deploy --project=<your-preferred-project-name> https://jsr.io/@std/http/1.0.0-rc.5/file_server.ts
 ```
 
 To give a little more explanation of these commands: Because this is a static


### PR DESCRIPTION
## Why?

Working tutorials.

## What?

- point to the latest working @std/http
- actually use a real file for the entry point, so it does not fail

> [!NOTE]
> For the latest 1.0.x version to work, see https://github.com/denoland/std/pull/6033

## Alternative?

- Enable JSR as an entrypoint: https://github.com/denoland/deployctl/issues/304