### PR TITLE
fixed incorrect href for Websocket under Deno API

### DIFF
--- a/index.page.tsx
+++ b/index.page.tsx
@@ -270,7 +270,7 @@ export default function () {
                     },
                     {
                       text: "Websocket",
-                      href: "/api/deno/websocket",
+                      href: "/api/deno/web-sockets",
                     },
                     {
                       text: "View all Deno APIs",
@@ -489,7 +489,7 @@ function ContentItem(props: {
 
   return (
     <div>
-      <h4 className="text-lg font-semibold mb-1">{props.title}</h4>
+      <h4 className="mb-1 text-lg font-semibold">{props.title}</h4>
       <p className="mb-3">{props.description}</p>
       <a className={`homepage-link ${productClass}`} href={props.link}>
         {props.linktext}{" "}
@@ -513,7 +513,7 @@ function LinkList(props: {
     : "help-link";
   return (
     <div>
-      <h4 className="text-lg font-semibold mb-1">{props.title}</h4>
+      <h4 className="mb-1 text-lg font-semibold">{props.title}</h4>
       {props.links.map((link, index) => (
         <a
           key={index}


### PR DESCRIPTION
Currently from the official [docs](https://docs.deno.com/) website, when someone clicks on WebSocket under Deno API, it redirects to a Not-found page. 

Expected Behavior: Should redirect to the correct page.

Reason: a small typo in the href associated with [it](https://github.com/denoland/docs/blob/33fc25bccb53a9bed708966ccd01880e2f3c862f/index.page.tsx#L273). 
Current href: "/api/deno/websocket"
Correct href:  "/api/deno/web-sockets"

![image](https://github.com/user-attachments/assets/61cfa6d2-a863-44da-a04a-de32ffc70b76)
