### PR TITLE
changes cookies to canvas from the list of Web APIs

### DIFF
--- a/index.page.tsx
+++ b/index.page.tsx
@@ -270,7 +270,7 @@ export default function () {
                     },
                     {
                       text: "Websocket",
-                      href: "/api/deno/websocket",
+                      href: "/api/deno/web-sockets",
                     },
                     {
                       text: "View all Deno APIs",
@@ -287,8 +287,8 @@ export default function () {
                       href: "/api/web/cache",
                     },
                     {
-                      text: "Cookies",
-                      href: "/api/web/cookies",
+                      text: "Canvas",
+                      href: "/api/web/canvas",
                     },
                     {
                       text: "Fetch",
@@ -489,7 +489,7 @@ function ContentItem(props: {
 
   return (
     <div>
-      <h4 className="text-lg font-semibold mb-1">{props.title}</h4>
+      <h4 className="mb-1 text-lg font-semibold">{props.title}</h4>
       <p className="mb-3">{props.description}</p>
       <a className={`homepage-link ${productClass}`} href={props.link}>
         {props.linktext}{" "}
@@ -513,7 +513,7 @@ function LinkList(props: {
     : "help-link";
   return (
     <div>
-      <h4 className="text-lg font-semibold mb-1">{props.title}</h4>
+      <h4 className="mb-1 text-lg font-semibold">{props.title}</h4>
       {props.links.map((link, index) => (
         <a
           key={index}


### PR DESCRIPTION
Changes the option from Cookies to Canvas. Cookies does not exist in the list of web api in this [page](https://docs.deno.com/api/web/)

When someone clicks on Cookies from the list under [Web APIs](https://docs.deno.com/) , it redirects them to a not-found page. I believe it will be a better option to change it to a link that exists. 

![image](https://github.com/user-attachments/assets/50bfcb9d-d687-408c-87e9-bfa8e49529ee)
