### PR TITLE
fix: Link to 'deno install' subcommand

### DIFF
--- a/runtime/_data.ts
+++ b/runtime/_data.ts
@@ -91,7 +91,7 @@ export const sidebar = [
           },
           {
             label: "deno install",
-            id: "/runtime/reference/cli/script_installer/",
+            id: "/runtime/reference/cli/install/",
           },
           {
             label: "deno jupyter",


### PR DESCRIPTION
This got broken by mistake by https://github.com/denoland/docs/pull/906, not yet
sure how that happened.