### PR TITLE
Add redirect for /go/lsp

### DIFF
--- a/go.json
+++ b/go.json
@@ -23,6 +23,7 @@
   "fmt": "/runtime/manual/tools/formatter",
   "info": "/runtime/manual/tools/dependency_inspector",
   "lint": "/runtime/manual/tools/linter",
+  "lsp": "/runtime/reference/cli/lsp",
   "run": "/runtime/manual/tools/run",
   "serve": "/runtime/manual/tools/serve",
   "test": "/runtime/manual/tools/test",


### PR DESCRIPTION
When running `deno lsp --help` you can see this help:

> How to connect various editors and IDEs to 'deno lsp': https://docs.deno.com/go/lsp

That page/redirect doesn't exists.
This PR adds a redirect for that page.