### PR TITLE
lsp internals page, old url is same as current url -> 301 redirect loop

### DIFF
--- a/runtime/reference/cli/lsp_integration.md
+++ b/runtime/reference/cli/lsp_integration.md
@@ -1,7 +1,6 @@
 ---
 title: "Language Server Integration"
 oldUrl:
-- /runtime/reference/cli/lsp_integration/
 - /runtime/manual/reference/lsp/
 - /runtime/manual/advanced/language_server/overview/
 - /runtime/manual/advanced/language_server/imports/


### PR DESCRIPTION
When visiting https://docs.deno.com/runtime/reference/cli/lsp_integration/ there is an eternal redirect loop. 

In that markdown page is an oldUrl specified that is the same as the correct url. This PR just removes that line and the page works again. (after the 301 cache is cleared in the browser)
