### PR TITLE
update cli menu in sidebar

### DIFF
--- a/runtime/_data.ts
+++ b/runtime/_data.ts
@@ -46,11 +46,6 @@ export const sidebar = [
       {
         label: "Deno CLI",
         items: [
-          "/runtime/reference/cli/unstable_flags/",
-          {
-            label: "Environment Variables",
-            id: "/runtime/reference/cli/env_variables/",
-          },
           {
             label: "deno add",
             id: "/runtime/reference/cli/add/",
@@ -151,6 +146,7 @@ export const sidebar = [
             label: "deno upgrade",
             id: "/runtime/reference/cli/upgrade/",
           },
+          "/runtime/reference/cli/unstable_flags/",
         ],
       },
       {
@@ -188,7 +184,7 @@ export const sidebar = [
       "/runtime/reference/migration_guide/",
       {
         label: "LSP integration",
-        id: "/runtime/reference/cli/lsp_integration/",
+        id: "/runtime/reference/lsp_integration/",
       },
     ],
   },

--- a/runtime/reference/cli/all_commands.md
+++ b/runtime/reference/cli/all_commands.md
@@ -8,7 +8,23 @@ runtime environment from your terminal or command prompt. The CLI has a number
 of subcommands that can be used to perform different tasks, check the links
 below for more information on each subcommand.
 
+## Execution
+
+- [deno run](/runtime/reference/cli/run/) - run a script
+- [deno serve](/runtime/reference/cli/serve/) - run a web server
+- [deno task](/runtime/reference/cli/task_runner/) - run a task
+- [deno repl](/runtime/reference/cli/repl/) - starts a read-eval-print-loop
+- [deno eval](/runtime/reference/cli/eval/) - evaluate provided script
+
+## Dependency management
+
 - [deno add](/runtime/reference/cli/add) - Add dependencies
+- [deno install](/runtime/reference/cli/install/) - install a dependency or a
+- [deno uninstall](/runtime/reference/cli/uninstall/) - uninstall a dependency
+- [deno remove](/runtime/reference/cli/remove) - Remove dependencies
+
+## Tooling
+
 - [deno bench](/runtime/reference/cli/benchmarker/) - benchmarking tool
 - [deno check](/runtime/reference/cli/check/) - type check your program without
   running it
@@ -20,27 +36,22 @@ below for more information on each subcommand.
   reports
 - [deno doc](/runtime/reference/cli/documentation_generator/) - generate
   documentation for a module
-- [deno eval](/runtime/reference/cli/eval/) - evaluate provided script
 - [deno fmt](/runtime/reference/cli/formatter/) - format your code
 - [deno info](/runtime/reference/cli/dependency_inspector/) - inspect an ES
   module and all of its dependencies
 - [deno init](/runtime/reference/cli/init/) - create a new project
-- [deno install](/runtime/reference/cli/install/) - install a dependency or a
   script
 - [deno jupyter](/runtime/reference/cli/jupyter/) - run a Jupyter notebook
 - [deno lint](/runtime/reference/cli/linter/) - lint your code
 - [deno lsp](/runtime/reference/cli/lsp/) - language server protocol integration
 - [deno publish](/runtime/reference/cli/publish/) - publish a module
-- [deno remove](/runtime/reference/cli/remove) - Remove dependencies
-- [deno repl](/runtime/reference/cli/repl/) - starts a read-eval-print-loop
-- [deno run](/runtime/reference/cli/run/) - run a script
-- [deno serve](/runtime/reference/cli/serve/) - run a web server
-- [deno task](/runtime/reference/cli/task_runner/) - run a task
 - [deno test](/runtime/reference/cli/test/) - run your tests
 - [deno types](/runtime/reference/cli/types/) - print runtime types
-- [deno uninstall](/runtime/reference/cli/uninstall/) - uninstall a dependency
   or a script
 - [deno upgrade](/runtime/reference/cli/upgrade/) - upgrade Deno to the latest
   version
-- [environment variables](/runtime/reference/cli/env_variables/)
-- [unstable feature flags](/runtime/reference/cli/unstable_flags/)
+
+## Other
+
+- [Unstable feature flags](/runtime/reference/cli/unstable_flags/)
+- [Integrating the Deno LSP](/runtime/reference/lsp_integration/)

--- a/runtime/reference/cli/all_commands.md
+++ b/runtime/reference/cli/all_commands.md
@@ -18,36 +18,29 @@ below for more information on each subcommand.
 
 ## Dependency management
 
-- [deno add](/runtime/reference/cli/add) - Add dependencies
-- [deno install](/runtime/reference/cli/install/) - install a dependency or a
-- [deno uninstall](/runtime/reference/cli/uninstall/) - uninstall a dependency
+- [deno add](/runtime/reference/cli/add) - add dependencies
+- [deno install](/runtime/reference/cli/install/) - install a dependency or a script
+- [deno uninstall](/runtime/reference/cli/uninstall/) - uninstall a dependency or a script
 - [deno remove](/runtime/reference/cli/remove) - Remove dependencies
 
 ## Tooling
 
 - [deno bench](/runtime/reference/cli/benchmarker/) - benchmarking tool
-- [deno check](/runtime/reference/cli/check/) - type check your program without
-  running it
-- [deno compile](/runtime/reference/cli/compiler/) - compile a program into a
-  standalone executable
-- [deno completions](/runtime/reference/cli/completions/) - generate shell
-  completions
-- [deno coverage](/runtime/reference/cli/coverage/) - generate test coverage
-  reports
-- [deno doc](/runtime/reference/cli/documentation_generator/) - generate
-  documentation for a module
+- [deno check](/runtime/reference/cli/check/) - type check your program without running it
+- [deno compile](/runtime/reference/cli/compiler/) - compile a program into a standalone executable
+- [deno completions](/runtime/reference/cli/completions/) - generate shell completions
+- [deno coverage](/runtime/reference/cli/coverage/) - generate test coverage reports
+- [deno doc](/runtime/reference/cli/documentation_generator/) - generate documentation for a module
 - [deno fmt](/runtime/reference/cli/formatter/) - format your code
-- [deno info](/runtime/reference/cli/dependency_inspector/) - inspect an ES
-  module and all of its dependencies
+- [deno info](/runtime/reference/cli/dependency_inspector/) - inspect an ES module and all of its dependencies
 - [deno init](/runtime/reference/cli/init/) - create a new project script
 - [deno jupyter](/runtime/reference/cli/jupyter/) - run a Jupyter notebook
 - [deno lint](/runtime/reference/cli/linter/) - lint your code
 - [deno lsp](/runtime/reference/cli/lsp/) - language server protocol integration
 - [deno publish](/runtime/reference/cli/publish/) - publish a module
 - [deno test](/runtime/reference/cli/test/) - run your tests
-- [deno types](/runtime/reference/cli/types/) - print runtime types or a script
-- [deno upgrade](/runtime/reference/cli/upgrade/) - upgrade Deno to the latest
-  version
+- [deno types](/runtime/reference/cli/types/) - print runtime types
+- [deno upgrade](/runtime/reference/cli/upgrade/) - upgrade Deno to the latest version
 
 ## Other
 

--- a/runtime/reference/cli/all_commands.md
+++ b/runtime/reference/cli/all_commands.md
@@ -41,7 +41,7 @@ below for more information on each subcommand.
 - [deno fmt](/runtime/reference/cli/formatter/) - format your code
 - [deno info](/runtime/reference/cli/dependency_inspector/) - inspect an ES
   module and all of its dependencies
-- [deno init](/runtime/reference/cli/init/) - create a new project script
+- [deno init](/runtime/reference/cli/init/) - create a new project
 - [deno jupyter](/runtime/reference/cli/jupyter/) - run a Jupyter notebook
 - [deno lint](/runtime/reference/cli/linter/) - lint your code
 - [deno lsp](/runtime/reference/cli/lsp/) - language server protocol integration

--- a/runtime/reference/cli/all_commands.md
+++ b/runtime/reference/cli/all_commands.md
@@ -19,20 +19,28 @@ below for more information on each subcommand.
 ## Dependency management
 
 - [deno add](/runtime/reference/cli/add) - add dependencies
-- [deno install](/runtime/reference/cli/install/) - install a dependency or a script
-- [deno uninstall](/runtime/reference/cli/uninstall/) - uninstall a dependency or a script
+- [deno install](/runtime/reference/cli/install/) - install a dependency or a
+  script
+- [deno uninstall](/runtime/reference/cli/uninstall/) - uninstall a dependency
+  or a script
 - [deno remove](/runtime/reference/cli/remove) - Remove dependencies
 
 ## Tooling
 
 - [deno bench](/runtime/reference/cli/benchmarker/) - benchmarking tool
-- [deno check](/runtime/reference/cli/check/) - type check your program without running it
-- [deno compile](/runtime/reference/cli/compiler/) - compile a program into a standalone executable
-- [deno completions](/runtime/reference/cli/completions/) - generate shell completions
-- [deno coverage](/runtime/reference/cli/coverage/) - generate test coverage reports
-- [deno doc](/runtime/reference/cli/documentation_generator/) - generate documentation for a module
+- [deno check](/runtime/reference/cli/check/) - type check your program without
+  running it
+- [deno compile](/runtime/reference/cli/compiler/) - compile a program into a
+  standalone executable
+- [deno completions](/runtime/reference/cli/completions/) - generate shell
+  completions
+- [deno coverage](/runtime/reference/cli/coverage/) - generate test coverage
+  reports
+- [deno doc](/runtime/reference/cli/documentation_generator/) - generate
+  documentation for a module
 - [deno fmt](/runtime/reference/cli/formatter/) - format your code
-- [deno info](/runtime/reference/cli/dependency_inspector/) - inspect an ES module and all of its dependencies
+- [deno info](/runtime/reference/cli/dependency_inspector/) - inspect an ES
+  module and all of its dependencies
 - [deno init](/runtime/reference/cli/init/) - create a new project script
 - [deno jupyter](/runtime/reference/cli/jupyter/) - run a Jupyter notebook
 - [deno lint](/runtime/reference/cli/linter/) - lint your code
@@ -40,7 +48,8 @@ below for more information on each subcommand.
 - [deno publish](/runtime/reference/cli/publish/) - publish a module
 - [deno test](/runtime/reference/cli/test/) - run your tests
 - [deno types](/runtime/reference/cli/types/) - print runtime types
-- [deno upgrade](/runtime/reference/cli/upgrade/) - upgrade Deno to the latest version
+- [deno upgrade](/runtime/reference/cli/upgrade/) - upgrade Deno to the latest
+  version
 
 ## Other
 

--- a/runtime/reference/cli/all_commands.md
+++ b/runtime/reference/cli/all_commands.md
@@ -39,15 +39,13 @@ below for more information on each subcommand.
 - [deno fmt](/runtime/reference/cli/formatter/) - format your code
 - [deno info](/runtime/reference/cli/dependency_inspector/) - inspect an ES
   module and all of its dependencies
-- [deno init](/runtime/reference/cli/init/) - create a new project
-  script
+- [deno init](/runtime/reference/cli/init/) - create a new project script
 - [deno jupyter](/runtime/reference/cli/jupyter/) - run a Jupyter notebook
 - [deno lint](/runtime/reference/cli/linter/) - lint your code
 - [deno lsp](/runtime/reference/cli/lsp/) - language server protocol integration
 - [deno publish](/runtime/reference/cli/publish/) - publish a module
 - [deno test](/runtime/reference/cli/test/) - run your tests
-- [deno types](/runtime/reference/cli/types/) - print runtime types
-  or a script
+- [deno types](/runtime/reference/cli/types/) - print runtime types or a script
 - [deno upgrade](/runtime/reference/cli/upgrade/) - upgrade Deno to the latest
   version
 

--- a/runtime/reference/cli/unstable_flags.md
+++ b/runtime/reference/cli/unstable_flags.md
@@ -1,5 +1,5 @@
 ---
-title: "Unstable Feature Flags"
+title: "Unstable feature flags"
 oldUrl:
  - /runtime/tools/unstable_flags/
  - /runtime/manual/tools/unstable_flags/

--- a/runtime/reference/env_variables.md
+++ b/runtime/reference/env_variables.md
@@ -1,6 +1,6 @@
 ---
 title: "Environment variables"
-oldUrl: 
+oldUrl:
 - /runtime/manual/basics/env_variables/
 - /runtime/reference/cli/env_variables/
 ---

--- a/runtime/reference/env_variables.md
+++ b/runtime/reference/env_variables.md
@@ -1,6 +1,8 @@
 ---
 title: "Environment variables"
-oldUrl: /runtime/manual/basics/env_variables/
+oldUrl: 
+- /runtime/manual/basics/env_variables/
+- /runtime/reference/cli/env_variables/
 ---
 
 There are a few ways to use environment variables in Deno:

--- a/runtime/reference/lsp_integration.md
+++ b/runtime/reference/lsp_integration.md
@@ -5,6 +5,7 @@ oldUrl:
 - /runtime/manual/advanced/language_server/overview/
 - /runtime/manual/advanced/language_server/imports/
 - /runtime/manual/advanced/language_server/testing_api/
+- /runtime/reference/cli/lsp_integration/
 ---
 
 :::tip


### PR DESCRIPTION
Remove env variables from CLI section (same content is covered in references)
Reorder "all commands" list to match --help output
Update CLI sidebar order
Move LSP integration file into references now that its sidebar item is under Reference not CLI