### PR TITLE
Limit the concurrency of link checker

### DIFF
--- a/.github/workflows/link_checker.ts
+++ b/.github/workflows/link_checker.ts
@@ -1,11 +1,13 @@
 import { DOMParser } from "jsr:@b-fuze/deno-dom";
 
+type Element = import("jsr:@b-fuze/deno-dom").Element;
+
 const visitedPages = new Set<string>();
 
 const rootURL = new URL(Deno.env.get("DOCS_ROOT")!);
 const rootPage = await fetch(rootURL).then((res) => res.text());
 
-visitedPages.add(rootURL);
+visitedPages.add(rootURL.href);
 let hasInvalidHrefs = false;
 
 await traversePage(rootURL, rootPage);
@@ -16,41 +18,49 @@ if (hasInvalidHrefs) {
 
 async function traversePage(url: URL, content: string) {
   const doc = new DOMParser().parseFromString(content, "text/html");
-  await Promise.allSettled([...doc.querySelectorAll("a").values()]
-    .map((a) => {
-      const href = a.getAttribute("href")?.trim();
-      if (!href) {
-        hasInvalidHrefs = true;
-        console.error(`Empty href on '${url.pathname}': ${a.outerHTML}`);
-        return;
+  // TODO(kt3k): Queue tasks and run them in limited concurrency
+  for (const a of doc.querySelectorAll("a")) {
+    await checkAnchor(a, url);
+  }
+}
+
+// deno-lint-ignore require-await
+async function checkAnchor(a: Element, url: URL) {
+  const href = a.getAttribute("href")?.trim();
+  if (!href) {
+    hasInvalidHrefs = true;
+    console.error(`Empty href on '${url.pathname}': ${a.outerHTML}`);
+    return;
+  }
+
+  if (
+    href.startsWith("http") || href.startsWith("mailto:") ||
+    href.startsWith("vscode:")
+  ) {
+    return;
+  }
+
+  const aURL = new URL(href, url);
+  if (aURL.pathname.startsWith("/api")) {
+    return;
+  }
+
+  if (visitedPages.has(aURL.href)) {
+    return;
+  }
+
+  visitedPages.add(aURL.href);
+
+  return fetch(aURL).then((res) => {
+    if (res.status === 200) {
+      if (res.headers.get("content-type")?.includes("text/html")) {
+        return res.text().then((text) => traversePage(aURL, text));
       }
+    } else {
+      hasInvalidHrefs = true;
+      console.error(`${res.status} on '${url.pathname}': ${href}`);
+    }
 
-      if (href.startsWith("http") || href.startsWith("mailto")) {
-        return;
-      }
-
-      const aURL = new URL(href, url);
-      if (aURL.pathname.startsWith("/api")) {
-        return;
-      }
-
-      if (visitedPages.has(aURL.href)) {
-        return;
-      }
-
-      visitedPages.add(aURL.href);
-
-      return fetch(aURL).then((res) => {
-        if (res.status === 200) {
-          if (res.headers.get("content-type")?.includes("text/html")) {
-            return res.text().then((text) => traversePage(aURL, text));
-          }
-        } else {
-          hasInvalidHrefs = true;
-          console.error(`${res.status} on '${url.pathname}': ${href}`);
-        }
-
-        return res.body?.cancel();
-      });
-    }));
+    return res.body?.cancel();
+  });
 }

--- a/.github/workflows/link_checker.ts
+++ b/.github/workflows/link_checker.ts
@@ -1,8 +1,8 @@
 import { DOMParser } from "jsr:@b-fuze/deno-dom";
-
-type Element = import("jsr:@b-fuze/deno-dom").Element;
+import RunQueue from "npm:run-queue@2";
 
 const visitedPages = new Set<string>();
+const queue = new RunQueue({ maxConcurrency: 10 });
 
 const rootURL = new URL(Deno.env.get("DOCS_ROOT")!);
 const rootPage = await fetch(rootURL).then((res) => res.text());
@@ -10,55 +10,58 @@ const rootPage = await fetch(rootURL).then((res) => res.text());
 visitedPages.add(rootURL.href);
 let hasInvalidHrefs = false;
 
-await traversePage(rootURL, rootPage);
+traversePage(rootURL, rootPage);
+
+await queue.run();
+
+console.log("Total pages checked:", visitedPages.size);
 
 if (hasInvalidHrefs) {
   Deno.exit(1);
 }
 
-async function traversePage(url: URL, content: string) {
+function traversePage(url: URL, content: string) {
+  console.log("Checking", url.href);
   const doc = new DOMParser().parseFromString(content, "text/html");
-  // TODO(kt3k): Queue tasks and run them in limited concurrency
   for (const a of doc.querySelectorAll("a")) {
-    await checkAnchor(a, url);
+    const href = a.getAttribute("href")?.trim();
+    if (!href) {
+      hasInvalidHrefs = true;
+      console.error(`Empty href on '${url.pathname}': ${a.outerHTML}`);
+      continue;
+    }
+
+    if (
+      href.startsWith("http") || href.startsWith("mailto") ||
+      href.startsWith("vscode:")
+    ) {
+      continue;
+    }
+
+    const aURL = new URL(href, url);
+    if (aURL.pathname.startsWith("/api")) {
+      continue;
+    }
+
+    aURL.hash = "";
+
+    if (visitedPages.has(aURL.href)) {
+      continue;
+    }
+    visitedPages.add(aURL.href);
+    queue.add(0, fetchUrl, [href, aURL, url]);
   }
 }
 
-// deno-lint-ignore require-await
-async function checkAnchor(a: Element, url: URL) {
-  const href = a.getAttribute("href")?.trim();
-  if (!href) {
-    hasInvalidHrefs = true;
-    console.error(`Empty href on '${url.pathname}': ${a.outerHTML}`);
-    return;
-  }
-
-  if (
-    href.startsWith("http") || href.startsWith("mailto:") ||
-    href.startsWith("vscode:")
-  ) {
-    return;
-  }
-
-  const aURL = new URL(href, url);
-  if (aURL.pathname.startsWith("/api")) {
-    return;
-  }
-
-  if (visitedPages.has(aURL.href)) {
-    return;
-  }
-
-  visitedPages.add(aURL.href);
-
-  return fetch(aURL).then((res) => {
+function fetchUrl(href: string, urlToCheck: URL, baseUrl: URL) {
+  return fetch(urlToCheck).then((res) => {
     if (res.status === 200) {
       if (res.headers.get("content-type")?.includes("text/html")) {
-        return res.text().then((text) => traversePage(aURL, text));
+        return res.text().then((text) => traversePage(urlToCheck, text));
       }
     } else {
       hasInvalidHrefs = true;
-      console.error(`${res.status} on '${url.pathname}': ${href}`);
+      console.error(`${res.status} on '${baseUrl.pathname}': ${href}`);
     }
 
     return res.body?.cancel();

--- a/deno.lock
+++ b/deno.lock
@@ -54,6 +54,7 @@
     "npm:preact@*": "10.23.2",
     "npm:preact@10.23.2": "10.23.2",
     "npm:prismjs@1.29.0": "1.29.0",
+    "npm:run-queue@2": "2.0.1",
     "npm:tailwindcss@*": "3.4.10_postcss@8.4.47",
     "npm:tailwindcss@^3.4.9": "3.4.10_postcss@8.4.47",
     "npm:unidecode@1.1.0": "1.1.0"
@@ -439,6 +440,9 @@
         "normalize-path",
         "picomatch"
       ]
+    },
+    "aproba@2.0.0": {
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
     },
     "arg@5.0.2": {
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
@@ -1267,6 +1271,12 @@
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "dependencies": [
         "queue-microtask"
+      ]
+    },
+    "run-queue@2.0.1": {
+      "integrity": "sha512-dkU5pUwpmeNKdsApBU6eBdUdkoSwx+yRnoi3Ax745evJDNx7NQRsE2o3AsXbye5GqbKqZ9HJFYxZ2laOoNE1Dg==",
+      "dependencies": [
+        "aproba"
       ]
     },
     "safe-buffer@5.2.1": {


### PR DESCRIPTION
Currently link checker causes `Reached heap limit` error in CI. This PR tries to fix it.

Currently the link checker checks all `<a>` tags concurrently (and it also does that recursively if it finds a new page). This PR limits the concurrency to 10 and tries to prevent the memory error.

(This PR also removes the `.hash` property from URL before visiting. This removes the duplicated checks of URLs which only differ in hash part.)