### PR TITLE
add temporary deno 2.0 banner

### DIFF
--- a/index.page.tsx
+++ b/index.page.tsx
@@ -78,6 +78,19 @@ export default function () {
 
         {/* Main content  */}
         <div class="flex flex-col gap-8 md:gap-16">
+          {/* Temporary banner  */}
+          <div class="flex flex-col gap-4 p-4 bg-runtime-50 border-l-4 border-runtime-500">
+            <p class="text-lg">
+              <strong>Deno 2.0</strong> is out now! Learn about{"  "}
+              <a
+                href="/runtime/reference/migration_guide"
+                class="runtime-link underline underline-offset-4"
+              >
+                what has changed
+              </a>{" "}
+              in the release.
+            </p>
+          </div>
           {/* Runtime content */}
           <div class="flex flex-col gap-8">
             {/* Section Header */}


### PR DESCRIPTION
Adds a banner to the homepage to announce 2.0

<img width="797" alt="Screenshot 2024-10-09 at 10 21 29 AM" src="https://github.com/user-attachments/assets/8e2535b1-cc35-47e4-9363-e00e3a52bdae">
