### PR TITLE
set homepage links to normal font weight

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -189,7 +189,7 @@ body:not(:has(.ddoc)) {
 }
 
 .homepage-link {
-  @apply block font-semibold underline underline-offset-4;
+  @apply block font-normal underline underline-offset-4;
 }
 
 .deploy-link {


### PR DESCRIPTION
Reduce font weight on homepage links so they don't overshadow the section headers. 