### PR TITLE
Fixing the deploy example to include the --global parameter

### DIFF
--- a/deploy/manual/index.md
+++ b/deploy/manual/index.md
@@ -48,7 +48,7 @@ curl -fsSL https://deno.land/install.sh | sh
 After Deno is installed, install the [`deployctl`](./deployctl.md) utility:
 
 ```
-deno install -A jsr:@deno/deployctl
+deno install -A jsr:@deno/deployctl --global
 ```
 
 You can confirm `deployctl` has been installed correctly by running:


### PR DESCRIPTION
This addresses a issue I opened up on the docs repo.