### PR TITLE
Fix: redirect for Next.js tutorial link

### DIFF
--- a/runtime/tutorials/index.md
+++ b/runtime/tutorials/index.md
@@ -21,7 +21,7 @@ your favorite tools.
 ## Web frameworks and libraries
 
 - [React](/runtime/tutorials/how_to_with_npm/react/)
-- [Next.js](/runtime/tutorials/how_to_with_npm/react/)
+- [Next.js](/runtime/tutorials/how_to_with_npm/next/)
 - [Fresh](https://fresh.deno.dev/docs/getting-started/create-a-project)
 - [Vue.js](/runtime/tutorials/how_to_with_npm/vue/)
 - [Express](/runtime/tutorials/how_to_with_npm/express/)


### PR DESCRIPTION
This pull request includes a small but important change to the `runtime/tutorials/index.md` file. The change corrects the link for the Next.js tutorial to ensure it points to the correct URL.