### PR TITLE
docs: fix wrong format engine

### DIFF
--- a/runtime/fundamentals/linting_and_formatting.md
+++ b/runtime/fundamentals/linting_and_formatting.md
@@ -47,8 +47,8 @@ rules, plugins, and settings to tailor the linting process to your needs.
 
 Formatting is the process of automatically adjusting the layout of your code to
 adhere to a consistent style. Deno’s built-in formatter, `deno fmt`, uses the
-powerful [dprint](https://dprint.dev/) engine to ensure that your code is
-always clean, readable, and consistent.
+powerful [dprint](https://dprint.dev/) engine to ensure that your code is always
+clean, readable, and consistent.
 
 To format your code, simply execute the following command in your terminal:
 

--- a/runtime/fundamentals/linting_and_formatting.md
+++ b/runtime/fundamentals/linting_and_formatting.md
@@ -47,7 +47,7 @@ rules, plugins, and settings to tailor the linting process to your needs.
 
 Formatting is the process of automatically adjusting the layout of your code to
 adhere to a consistent style. Deno’s built-in formatter, `deno fmt`, uses the
-powerful [Prettier](https://prettier.io/) engine to ensure that your code is
+powerful [dprint](https://dprint.dev/) engine to ensure that your code is
 always clean, readable, and consistent.
 
 To format your code, simply execute the following command in your terminal:


### PR DESCRIPTION
We're using `dprint` in Deno, not `prettier`.