### PR TITLE
fix: web worker permissions caution block

### DIFF
--- a/runtime/reference/web_platform_apis.md
+++ b/runtime/reference/web_platform_apis.md
@@ -361,7 +361,7 @@ hello world
 
 ### Specifying worker permissions
 
-:::warning
+:::caution
 
 This is an unstable Deno feature. Learn more about
 [unstable features](/runtime/fundamentals/stability_and_releases/#unstable-apis).


### PR DESCRIPTION
`:::warning` does not render properly, must use `:::caution`