### PR TITLE
Add clarity to documentation for `deno install` and `deno uninstall` CLI subcommands

### DIFF
--- a/runtime/reference/cli/install.md
+++ b/runtime/reference/cli/install.md
@@ -13,7 +13,8 @@ command: install
 
 ### deno install
 
-Use this command to install all dependencies defined in `deno.json` and/or
+Use this command with no particular pacakges specified to install all dependencies
+defined in the `imports` field of `deno.json` and/or the `dependencies` field of
 `package.json`.
 
 The dependencies will be installed in the global cache, but if your project has
@@ -21,8 +22,8 @@ a `package.json` file, a local `node_modules` directory will be set up as well.
 
 ### deno install [PACKAGES]
 
-Use this command to install particular packages and add them to `deno.json` or
-`package.json`.
+Use this command with particular packages specified to add them to `imports` in
+`deno.json` or `dependencies` in `package.json`, and then immediately install them.
 
 ```shell
 $ deno install jsr:@std/testing npm:express
@@ -30,13 +31,14 @@ $ deno install jsr:@std/testing npm:express
 
 :::tip
 
-You can also use `deno add` which is an alias to `deno install [PACKAGES]`
+The [`deno add`](/runtime/reference/cli/add/) command will add packages to `imports`
+in `deno.json`, without installing the packages.
 
 :::
 
 If your project has a `package.json` file, the packages coming from npm will be
 added to `dependencies` in `package.json`. Otherwise all packages will be added
-to `deno.json`.
+to `imports` in `deno.json`.
 
 ### deno install --entrypoint [FILES]
 

--- a/runtime/reference/cli/uninstall.md
+++ b/runtime/reference/cli/uninstall.md
@@ -6,7 +6,7 @@ command: uninstall
 
 ## `deno uninstall [PACKAGES]`
 
-Remove dependencies specified in `deno.json` or `package.json`:
+Remove dependencies specified in `deno.json` or `package.json` and uninstall them:
 
 ```shell
 $ deno add npm:express
@@ -32,7 +32,8 @@ $ cat deno.json
 
 :::tip
 
-You can also use `deno remove` which is an alias to `deno uninstall [PACKAGES]`
+The [`deno remove`](/runtime/reference/cli/remove/) command will remove packages
+from the configuration file, without uninstalling the packages.
 
 :::
 
@@ -62,13 +63,6 @@ $ cat deno.json
   "imports": {}
 }
 ```
-
-:::info
-
-While dependencies are removed from the `deno.json` and `package.json` they
-still persist in the global cache for future use.
-
-:::
 
 If your project contains `package.json`, `deno uninstall` can work with it too:
 


### PR DESCRIPTION
# Commit 1
## Add clarity to documentation for `deno install` CLI subcommand
This commit adds clarity to the documentation of the `deno install` CLI subcommand.

# Commit 2
## Add clarity to documentation for `deno uninstall` CLI subcommand
This commit adds clarity to the documentation of the `deno uninstall` CLI subcommand.