### PR TITLE
update nav design flourishes

### DIFF
--- a/_components/Header.tsx
+++ b/_components/Header.tsx
@@ -60,7 +60,7 @@ export default function Header({
             name="API reference"
             hideOnMobile
           />
-          <span class="hidden lg:inline-block mx-2">//</span>
+          <span class="hidden lg:inline-block text-gray-300 mx-2">//</span>
           <HeaderItem
             url={url}
             activeOn="/deploy"
@@ -149,7 +149,7 @@ function HeaderItem({
     <a
       class={`${
         firstItem ? "ml-0" : ""
-      } mx-1 px-2 text-md hover:text-primary hover:bg-blue-50 hover:rounded text-nowrap flex items-center ${
+      } mx-1 px-2 text-md hover:text-primary hover:bg-blue-50 ring-1 ring-transparent hover:ring-blue-100 hover:rounded transition-colors duration-200 ease-in-out text-nowrap flex items-center ${
         activeOn && url.startsWith(activeOn)
           ? "text-primary mx-2.5 px-0.5 underline font-semibold underline-offset-[6px] decoration-primary/20"
           : ""
@@ -160,8 +160,8 @@ function HeaderItem({
       {external &&
         (
           <svg
-            width="13.5"
-            height="13.5"
+            width="10"
+            height="10"
             aria-hidden="true"
             viewBox="0 0 24 24"
             class="inline  ml-2"

--- a/_components/Sidebar.tsx
+++ b/_components/Sidebar.tsx
@@ -75,7 +75,7 @@ function SidebarSection(
       )}{" "}
       <ul aria-labelledby={categoryTitle}>
         {props.section.items.map((item) => (
-          <li class="mx-2 mt-1">
+          <li class="mx-2">
             {typeof item === "object" && "items" in item
               ? (
                 <SidebarCategory
@@ -99,7 +99,7 @@ function SidebarSection(
 }
 
 const LINK_CLASS =
-  "block px-3 py-1.5 text-[.8125rem] leading-4 font-normal text-gray-500 rounded-md hover:bg-blue-50 current:bg-blue-50 current:text-blue-500 transition-colors duration-200 ease-in-out select-none";
+  "block px-3 py-1.5 text-[.8125rem] leading-4 font-normal text-gray-500 rounded-md hover:bg-blue-50 ring-1 ring-transparent hover:ring-blue-100 current:bg-blue-50 current:text-blue-500 current:font-semibold transition-colors duration-200 ease-in-out select-none";
 
 function SidebarItem(props: {
   item: string | SidebarDoc_ | SidebarLink_;
@@ -121,7 +121,7 @@ function SidebarItem(props: {
   }
 
   return (
-    <li class="mx-2 mt-1">
+    <li class="mx-2">
       <a
         class={LINK_CLASS}
         href={"id" in item ? item.id : "href" in item ? item.href : undefined}

--- a/styles.css
+++ b/styles.css
@@ -206,16 +206,16 @@ body:not(:has(.ddoc)) {
 }
 
 /* Orama search style overrides */
-.searchbutton-module_searchbutton__gg7JJ {
-  @apply w-full border-gray-00 px-3 rounded-md gap-1 !important;
+button.searchbutton-module_searchbutton__gg7JJ {
+  @apply w-full border-gray-300 px-3 text-gray-500 rounded gap-1 !important;
 }
 
 .searchbutton-module_searchbutton__gg7JJ > svg {
-  @apply w-3.5 h-3.5 !important;
+  @apply w-3 h-3 !important;
 }
 
 .searchbutton-module_searchbutton__keys__qckL6 {
-  @apply border-0 py-0.5 text-gray-1 text-sm !important;
+  @apply border-0 py-0.5 text-gray-400 text-sm !important;
 }
 
 .searlchbutton-module_searchbutton__keys__qckL6 > kbd:first-of-type {


### PR DESCRIPTION
A few design updates for the side and top nav:

- less vertical space on nav link items
- light border on hover to help identify actively hovered items vs current page
- bolded text for current page to provide a secondary means of identifying current page
- adjustments to search box to make it match some of the other grays used on the page
- lightened the divider between top nav item types so it's more clear that its a divider and not an un-rendered link
- reducing icon size for external link so it doesn't stick out so much

<img width="1369" alt="Screenshot 2024-10-24 at 12 06 00 PM" src="https://github.com/user-attachments/assets/e28436d8-686d-4d61-ae3a-1a6ca87c71b5">
