### PR TITLE
feat: add example for hono

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -3,6 +3,8 @@
   "specifiers": {
     "jsr:@b-fuze/deno-dom@*": "0.1.48",
     "jsr:@davidbonnet/astring@1.8.6": "1.8.6",
+    "jsr:@hono/hono@*": "4.6.6",
+    "jsr:@hono/hono@4.6.6": "4.6.6",
     "jsr:@std/cli@1.0.4": "1.0.4",
     "jsr:@std/cli@^1.0.4": "1.0.4",
     "jsr:@std/collections@^1.0.5": "1.0.5",
@@ -74,6 +76,9 @@
     },
     "@deno/gfm@0.8.2": {
       "integrity": "a7528367cbd954a2d0de316bd0097ee92f06d2cb66502c8574de133ed223424f"
+    },
+    "@hono/hono@4.6.6": {
+      "integrity": "4856346894db3abfc4bdb89607b4d7bd84725236076fc922573def2b2b64130b"
     },
     "@std/cli@1.0.4": {
       "integrity": "79ca75add572a99a8ba93ae37ccbd8d43fb4e2b635a8a7ebebb4f2d092048764"
@@ -1740,6 +1745,21 @@
     "https://cdn.skypack.dev/-/universal-user-agent@v6.0.0-fUAPE3UH5QP7qG0fd0dH/dist=es2019,mode=imports/optimized/universal-user-agent.js": "24df9219684b303ca065c02733e601d11b3ed63a35ec8e473094006d65f6ded9",
     "https://cdn.skypack.dev/-/wrappy@v1.0.2-e8nLh7Qms0NRhbAbUpJP/dist=es2019,mode=imports/optimized/wrappy.js": "01dc1f36207f5400dad37bac2acddb2de0466953f289b8c84b7100e8b160fbb2",
     "https://cdn.skypack.dev/@octokit/core@3?dts": "7a987f1931a3102f29bb54a0ee09a9d4c99555e6a4cae98dd1e0127c9929dd36",
+    "https://deno.land/std@0.120.0/async/deadline.ts": "1d6ac7aeaee22f75eb86e4e105d6161118aad7b41ae2dd14f4cfd3bf97472b93",
+    "https://deno.land/std@0.120.0/async/debounce.ts": "b2f693e4baa16b62793fd618de6c003b63228db50ecfe3bd51fc5f6dc0bc264b",
+    "https://deno.land/std@0.120.0/async/deferred.ts": "ab60d46ba561abb3b13c0c8085d05797a384b9f182935f051dc67136817acdee",
+    "https://deno.land/std@0.120.0/async/delay.ts": "f2d8ccaa8ebc26594bd8b0989edfd8a96257a714c1dee2fb54d986e5bdd840ac",
+    "https://deno.land/std@0.120.0/async/mod.ts": "78425176fabea7bd1046ce3819fd69ce40da85c83e0f174d17e8e224a91f7d10",
+    "https://deno.land/std@0.120.0/async/mux_async_iterator.ts": "62abff3af9ff619e8f2adc96fc70d4ca020fa48a50c23c13f12d02ed2b760dbe",
+    "https://deno.land/std@0.120.0/async/pool.ts": "353ce4f91865da203a097aa6f33de8966340c91b6f4a055611c8c5d534afd12f",
+    "https://deno.land/std@0.120.0/async/tee.ts": "3e9f2ef6b36e55188de16a667c702ace4ad0cf84e3720379160e062bf27348ad",
+    "https://deno.land/std@0.120.0/http/http_status.ts": "2ff185827bff21c7be2807fcb09a6a2166464ba57fcd94afe805abab8e09070a",
+    "https://deno.land/std@0.120.0/http/server.ts": "d0be8a9da160255623e645f5b515fa1c6b65eecfbb9cad87ef8002d4f8d56616",
+    "https://deno.land/std@0.143.0/_util/assert.ts": "e94f2eb37cebd7f199952e242c77654e43333c1ac4c5c700e929ea3aa5489f74",
+    "https://deno.land/std@0.143.0/datetime/formatter.ts": "7c8e6d16a0950f400aef41b9f1eb9168249869776ec520265dfda785d746589e",
+    "https://deno.land/std@0.143.0/datetime/mod.ts": "dcab9ae7be83cbf74b7863e83bd16e7c646a8dea2f019092905630eb7a545739",
+    "https://deno.land/std@0.143.0/datetime/tokenizer.ts": "7381e28f6ab51cb504c7e132be31773d73ef2f3e1e50a812736962b9df1e8c47",
+    "https://deno.land/std@0.143.0/http/cookie.ts": "526f27762fad7bf84fbe491de7eba7c406057501eec6edcad7884a16b242fddf",
     "https://deno.land/std@0.170.0/_util/asserts.ts": "d0844e9b62510f89ce1f9878b046f6a57bf88f208a10304aab50efcb48365272",
     "https://deno.land/std@0.170.0/_util/os.ts": "8a33345f74990e627b9dfe2de9b040004b08ea5146c7c9e8fe9a29070d193934",
     "https://deno.land/std@0.170.0/encoding/base64.ts": "8605e018e49211efc767686f6f687827d7f5fd5217163e981d8d693105640d7a",
@@ -1785,6 +1805,13 @@
     "https://deno.land/std@0.179.0/streams/read_all.ts": "bfa220b0e1d06fa4d0cb5178baba8f8b466019a7411511982bfa2320ca292815",
     "https://deno.land/std@0.179.0/streams/reader_from_stream_reader.ts": "3fda9390ec8520c8a9ea2aba2579208b18880a7663d7a9feec8f193b7af14e41",
     "https://deno.land/std@0.179.0/streams/write_all.ts": "3b2e1ce44913f966348ce353d02fa5369e94115181037cd8b602510853ec3033",
+    "https://deno.land/x/case@2.1.1/lowerCase.ts": "86d5533f9587ed60003181591e40e648838c23f371edfa79d00288153d113b16",
+    "https://deno.land/x/case@2.1.1/normalCase.ts": "6a8b924da9ab0790d99233ae54bfcfc996d229cb91b2533639fe20972cc33dac",
+    "https://deno.land/x/case@2.1.1/snakeCase.ts": "ee2ab4e2c931d30bb79190d090c21eb5c00d1de1b7a9a3e7f33e035ae431333b",
+    "https://deno.land/x/case@2.1.1/types.ts": "8e2bd6edaa27c0d1972c0d5b76698564740f37b4d3787d58d1fb5f48de611e61",
+    "https://deno.land/x/case@2.1.1/vendor/camelCaseRegexp.ts": "7d9ff02aad4ab6429eeab7c7353f7bcdd6cc5909a8bd3dda97918c8bbb7621ae",
+    "https://deno.land/x/case@2.1.1/vendor/camelCaseUpperRegexp.ts": "292de54a698370f90adcdf95727993d09888b7f33d17f72f8e54ba75f7791787",
+    "https://deno.land/x/case@2.1.1/vendor/nonWordRegexp.ts": "c1a052629a694144b48c66b0175a22a83f4d61cb40f4e45293fc5d6b123f927e",
     "https://deno.land/x/cliffy@v0.25.7/_utils/distance.ts": "02af166952c7c358ac83beae397aa2fbca4ad630aecfcd38d92edb1ea429f004",
     "https://deno.land/x/cliffy@v0.25.7/ansi/ansi.ts": "7f43d07d31dd7c24b721bb434c39cbb5132029fa4be3dd8938873065f65e5810",
     "https://deno.land/x/cliffy@v0.25.7/ansi/ansi_escapes.ts": "885f61f343223f27b8ec69cc138a54bea30542924eacd0f290cd84edcf691387",
@@ -1969,6 +1996,7 @@
     "https://raw.githubusercontent.com/denoland/automation/0.19.2/mod.ts": "94c53674853b68977c3452262130d6430bdae2dfb5777b04c708d52fd9a73739",
     "https://raw.githubusercontent.com/denoland/automation/0.19.2/releases_md.ts": "4debb10b57849e20f97a58354773db22c2887b6a6a58134869366265729eb2e0",
     "https://raw.githubusercontent.com/denoland/automation/0.19.2/repo.ts": "046f848101b200f240796063ad7b956f85feddd4b46d1be59eac15a67f9a5e8b",
+    "https://raw.githubusercontent.com/denoland/ga4/04a1ce209116f158b5ef1658b957bdb109db68ed/mod.ts": "36f72ba1c90b5ebdb811427f367cd95fa6772d2de2fb45d6e57550501ee6d476",
     "https://unpkg.com/@orama/wc-components@0.1.5/dist/esm/ChatService-3d446bc4.js": "c7a63d27bcdacfcba2952ec532de284c17d31d6351664145d0f8b8f9d6f24ac1",
     "https://unpkg.com/@orama/wc-components@0.1.5/dist/esm/GlobalContext-0a87b8bd.js": "2cf4f45d144b13d67f93012d4f3bb72a102426bfc9f06fc202a6d710f2a0ac65",
     "https://unpkg.com/@orama/wc-components@0.1.5/dist/esm/PhCaretLeft-c5a6c8bf.js": "32c644c99663fb604bad42cf61740351ba3a9ec51d3252e6367529491516511c",

--- a/examples/hono.ts
+++ b/examples/hono.ts
@@ -1,0 +1,29 @@
+/**
+ * @title Hono HTTP server
+ * @difficulty intermediate
+ * @tags cli, deploy
+ * @run --allow-net <url>
+ * @resource {https://jsr.io/@hono/hono} Hono on jsr.io
+ * @resource {https://hono.dev/docs} Hono documentation
+ * @group Network
+ *
+ * An example of a HTTP server that uses the Hono framework.
+ */
+
+// Import the Hono framework
+import { Hono } from "jsr:@hono/hono";
+
+// Create a new Hono server
+const app = new Hono();
+
+// Define a route that responds with "Hello, World!"
+// The first argument is the path, the second is the request handler
+app.get("/", (c) => c.text("Hello, World!"));
+
+// Call Deno.serve with the request handler to start the server on the default port (8000)
+Deno.serve(app.fetch);
+
+// Test the server with: curl http://localhost:8000
+// Should output "Hello, World!"
+
+// Read more about Hono with Deno at https://hono.dev/docs/getting-started/deno


### PR DESCRIPTION
Adds a simple hello world example for [Hono](https://hono.dev/).

Just thought that since it was [announced](https://deno.com/blog/hono-on-jsr) on the Deno blog, there should be an example with explainer comments here :)