### PR TITLE
hint at running  deno install when using a package.json

### DIFF
--- a/runtime/fundamentals/configuration.md
+++ b/runtime/fundamentals/configuration.md
@@ -77,6 +77,8 @@ import express from "express";
 const app = express();
 ```
 
+Note that this will require you to run `deno install`.
+
 Read more about
 [module imports and dependencies](/runtime/fundamentals/modules/)
 


### PR DESCRIPTION
Added a line of test stating, "Note that this will require you to run `deno install` at `/runtime/fundamentals/configuration/#dependencies`

Resolves [#1009]