### PR TITLE
Fixes typo in Next.js tutorial

### DIFF
--- a/runtime/tutorials/how_to_with_npm/next.md
+++ b/runtime/tutorials/how_to_with_npm/next.md
@@ -113,7 +113,7 @@ export const GET = async (request: NextRequest, { params }: RouteParams) => {
   }
 
   const dinosaurData = data.find((item) =>
-    item.name.toLowerCase() === context.params.dinosaur.toLowerCase()
+    item.name.toLowerCase() === dinosaur.toLowerCase()
   );
 
   return Response.json(dinosaurData ? dinosaurData : "No dinosaur found.");


### PR DESCRIPTION
This PR fixes a typo caused by copy&pasting from React/Vue tutorials.
It refers to an undefined `context` variable.

Change has been tested.