### PR TITLE
Change types.ts filename

### DIFF
--- a/runtime/tutorials/how_to_with_npm/vue.md
+++ b/runtime/tutorials/how_to_with_npm/vue.md
@@ -293,7 +293,7 @@ dinosaur and a link to go back to the full list.
 First, we'll set up some types for the data we'll be fetching. Create a
 `types.ts` file in the `src` directory and add the following code:
 
-```ts title="types.d.ts"
+```ts title="types.ts"
 type Dinosaur = {
   name: string;
   description: string;


### PR DESCRIPTION
This PR fixes filename typo in the VueJS examples.
The text refers to `types.ts` but the example snippet had `types.d.ts`.

While technically both should work, the `tsconfig.app.json` includes only `*.ts` files, so the filename has to be `types.ts`.

Tutorial works with the change as expected.