### PR TITLE
fix(docs): Remove duplicated links in node_api docs

### DIFF
--- a/runtime/reference/node_apis.md
+++ b/runtime/reference/node_apis.md
@@ -50,7 +50,6 @@ importing them from the relevant `node:` module.
 | [`exports`](https://nodejs.org/api/globals.html#exports)                                                         | ✅                                 |
 | [`fetch`](https://nodejs.org/api/globals.html#fetch)                                                             | ✅                                 |
 | [`File`](https://nodejs.org/api/globals.html#class-file)                                                         | ✅                                 |
-| [`File`](https://nodejs.org/api/globals.html#class-file)                                                         | ✅                                 |
 | [`FormData`](https://nodejs.org/api/globals.html#class-formdata)                                                 | ✅                                 |
 | [`global`](https://nodejs.org/api/globals.html#global)                                                           | ✅                                 |
 | [`Headers`](https://nodejs.org/api/globals.html#class-headers)                                                   | ✅                                 |

--- a/runtime/reference/node_apis.md
+++ b/runtime/reference/node_apis.md
@@ -49,7 +49,6 @@ importing them from the relevant `node:` module.
 | [`EventTarget`](https://nodejs.org/api/globals.html#eventtarget)                                                 | ✅                                 |
 | [`exports`](https://nodejs.org/api/globals.html#exports)                                                         | ✅                                 |
 | [`fetch`](https://nodejs.org/api/globals.html#fetch)                                                             | ✅                                 |
-| [`fetch`](https://nodejs.org/api/globals.html#fetch)                                                             | ✅                                 |
 | [`File`](https://nodejs.org/api/globals.html#class-file)                                                         | ✅                                 |
 | [`File`](https://nodejs.org/api/globals.html#class-file)                                                         | ✅                                 |
 | [`FormData`](https://nodejs.org/api/globals.html#class-formdata)                                                 | ✅                                 |


### PR DESCRIPTION
Removes the duplicated `fetch` and `File` supported row from the Globals field.

![image](https://github.com/user-attachments/assets/6dcd716b-16e4-4649-8f38-311774004070)
