### PR TITLE
Add missing word in JSX docs

### DIFF
--- a/runtime/reference/jsx.md
+++ b/runtime/reference/jsx.md
@@ -7,7 +7,7 @@ oldUrl:
 ---
 
 Deno has built-in support for JSX in both `.jsx` files and `.tsx` files. JSX in
-Deno can be handy for server-side rendering or generating code browser
+Deno can be handy for server-side rendering or generating code for browser
 consumption.
 
 ## Default configuration


### PR DESCRIPTION
This pull request includes a minor change to the `runtime/reference/jsx.md` file to improve the clarity of the documentation.

Documentation improvement:

* [`runtime/reference/jsx.md`](diffhunk://#diff-97cac2c0f6729544e9c30f793213a249111703db2bb4925872741d7926472c93L10-R10): Corrected the phrase "generating code browser" to "generating code for browser" for better readability.