### PR TITLE
add banner for self-hosted

### DIFF
--- a/index.page.tsx
+++ b/index.page.tsx
@@ -352,7 +352,21 @@ export default function () {
               </div>
             </div>
           </div>
-
+          <div class="flex flex-col gap-4 p-4 bg-deploy-50 dark:bg-background-secondary border-l-4 text-deploy-foreground border-deploy-500">
+            <p class="text-lg">
+              Run Deno Deploy on your own infrastructure with our self-hosted
+              solution running on AWS, GCP, or Azure.{"  "}
+              <a
+                href="https://unf275cfh14.typeform.com/to/dIicJYSQ"
+                class="deploy-link underline underline-offset-4 external"
+              >
+                Learn more{" "}
+                <span aria-hidden="true" class="whitespace-pre">
+                  -&gt;
+                </span>
+              </a>
+            </p>
+          </div>
           {/* Deploy content */}
           <div class="flex flex-col gap-8">
             {/* Scection Header */}


### PR DESCRIPTION
Adds banner linking to the self-hosted screener before the deploy content. 

<img width="1203" alt="Screenshot 2024-11-12 at 4 24 30 PM" src="https://github.com/user-attachments/assets/50a8f8c5-f816-4e8a-b5ff-21ef7b381074">
