### PR TITLE
fix typo in group name for gzip example

### DIFF
--- a/examples/unzip-gzipped-file.ts
+++ b/examples/unzip-gzipped-file.ts
@@ -3,7 +3,7 @@
  * @difficulty beginner
  * @tags cli, deploy
  * @run --allow-write --allow-read <url>
- * @group File Systm
+ * @group File System
  *
  * An example of how to decompress a gzipped file and save it to disk.
  */


### PR DESCRIPTION
I'm so sorry, at some point during development I deleted an e in the gzip example. This caused a typo in the group name which led to a new group being created.

This PR fixes that typo so it is appropriately grouped.

![image](https://github.com/user-attachments/assets/b31bb18f-6bec-4341-a7f4-1ab75c094056)
