### PR TITLE
harmonize folder structure in text and code-snippet

### DIFF
--- a/runtime/tutorials/how_to_with_npm/react.md
+++ b/runtime/tutorials/how_to_with_npm/react.md
@@ -333,7 +333,7 @@ At this point the app is being served by the Vite development server. To serve
 the app in production, you can build the app with Vite and then serve the built
 files with Deno. To do so we'll need to update the api server to serve the built
 files. We'll write some middleware to do this. In your `api` directory create a
-new file called `routeStaticFilesFrom.ts` and add the following code:
+new folder `util` and a new file called `routeStaticFilesFrom.ts` and add the following code:
 
 ```ts title="routeStaticFilesFrom.ts"
 import { Next } from "jsr:@oak/oak/middleware";
@@ -366,7 +366,7 @@ middleware:
 import { Application, Router } from "@oak/oak";
 import { oakCors } from "@tajpouria/cors";
 import data from "./data.json" with { type: "json" };
-import routeStaticFilesFrom from "./api/routeStaticFilesFrom.ts";
+import routeStaticFilesFrom from "./util/routeStaticFilesFrom.ts";
 
 const router = new Router();
 

--- a/runtime/tutorials/how_to_with_npm/react.md
+++ b/runtime/tutorials/how_to_with_npm/react.md
@@ -333,7 +333,8 @@ At this point the app is being served by the Vite development server. To serve
 the app in production, you can build the app with Vite and then serve the built
 files with Deno. To do so we'll need to update the api server to serve the built
 files. We'll write some middleware to do this. In your `api` directory create a
-new folder `util` and a new file called `routeStaticFilesFrom.ts` and add the following code:
+new folder `util` and a new file called `routeStaticFilesFrom.ts` and add the
+following code:
 
 ```ts title="routeStaticFilesFrom.ts"
 import { Next } from "jsr:@oak/oak/middleware";


### PR DESCRIPTION
so https://github.com/denoland/tutorial-with-react/tree/main/api/util  and code snippet actually works with instruction given in text.
1. file is in repo in util - folder
2. file is not in /api/api/ folder, like code snippets states.
3. text says to create file in api-folder.

https://github.com/denoland/docs/pull/1125 can be closed then. or merge both pr together, so that a good end result is reached.