### PR TITLE
Added install command for NextJS 14

### DIFF
--- a/runtime/tutorials/how_to_with_npm/next.md
+++ b/runtime/tutorials/how_to_with_npm/next.md
@@ -28,6 +28,12 @@ run the following command to create a new Next.js app with Deno:
 deno run -A npm:create-next-app@latest
 ```
 
+If you need to migrate your existing Next 14 app, you can do:
+
+```sh
+deno run -A npm:create-next-app@14
+```
+
 When prompted, select the default options to create a new Next.js app with
 TypeScript.
 


### PR DESCRIPTION
The existing installation step doesn't work!! See https://questions.deno.com/m/1294573642491105343 https://github.com/denoland/deno/issues/26483

Some people may also want to migrate their existing Next13/14 apps to Deno2. This will help them clarify better instead of getting the latest Next setup with deno2.