### PR TITLE
fix: `deno check` redirecting to `deno compile`

### DIFF
--- a/runtime/reference/cli/compile.md
+++ b/runtime/reference/cli/compile.md
@@ -2,7 +2,6 @@
 title: "`deno compile`, standalone executables"
 oldUrl:
  - /runtime/manual/tools/compiler/
- - /runtime/reference/cli/check/
  - /runtime/reference/cli/compiler/
 command: compile
 ---


### PR DESCRIPTION
Fixes https://github.com/denoland/docs/issues/1185