### PR TITLE
Fix deploy/tutorials/vite.md (Step 2: Run the repo locally)

### DIFF
--- a/deploy/tutorials/vite.md
+++ b/deploy/tutorials/vite.md
@@ -25,7 +25,7 @@ Then, `cd` into the newly created project folder.
 To see and edit your new project locally you can run:
 
 ```sh
-deno task run
+deno task dev
 ```
 
 ## Step 3: Deploy your project with Deno Deploy


### PR DESCRIPTION
This pull request includes a small change to the `deploy/tutorials/vite.md` file. The change updates the command to run the project locally from `deno task run` to `deno task dev` to reflect the correct usage. The command of step 1 generates a `deno.json` which defines the following tasks:
  ```
"tasks": {
    "dev": "deno run -A --node-modules-dir npm:vite",
    "build": "deno run -A --node-modules-dir npm:vite build",
    "preview": "deno run -A --node-modules-dir npm:vite preview",
    "serve": "deno run --allow-net --allow-read jsr:@std/http@1/file-server dist/"
  }, 
```
the task `run` does not appear in this list, so the correct one should be `dev`.