### PR TITLE
Learn landing page

### DIFF
--- a/_components/Header.tsx
+++ b/_components/Header.tsx
@@ -59,7 +59,7 @@ export default function Header({
             url={url}
             activeOn="/learn"
             href="/learn"
-            name="Learning hub"
+            name="Learn"
             hideOnMobile
           />
           <span class="hidden xl:inline-block text-foreground-secondary mx-2">

--- a/_config.ts
+++ b/_config.ts
@@ -127,7 +127,7 @@ site.use(
 );
 site.use(
   esbuild({
-    extensions: [".client.ts"],
+    extensions: [".client.ts", ".client.js"],
     options: {
       minify: false,
       splitting: true,

--- a/_includes/layout.tsx
+++ b/_includes/layout.tsx
@@ -72,6 +72,7 @@ export default function Layout(props: Lume.Data) {
         <script type="module" src="/search.client.js"></script>
         <script type="module" src="/tabs.client.js"></script>
         <script type="module" src="/feedback.client.js"></script>
+        <script type="module" src="/youtube-lite.client.js"></script>
         <script
           async
           src="https://www.googletagmanager.com/gtm.js?id=GTM-5B5TH8ZJ"

--- a/index.page.tsx
+++ b/index.page.tsx
@@ -9,12 +9,12 @@ export const sidebar = [
         id: "/runtime/",
       },
       {
-        label: "Examples",
-        id: "/examples/",
-      },
-      {
         label: "API reference",
         id: "/api/deno",
+      },
+      {
+        label: "Learn",
+        id: "/learn/",
       },
       {
         label: "Deploy",

--- a/learn/_components/EmbedVideo.tsx
+++ b/learn/_components/EmbedVideo.tsx
@@ -1,0 +1,37 @@
+/**
+ * Embed a YouTube video.
+ * @param props.id - The YouTube ID or URL.
+ * @returns A custom element that embeds the YouTube video with Lite YouTube Embed.
+ */
+export function EmbedVideo(
+  props: { id: string },
+) {
+  const videoid = extractID(props.id);
+  return (
+    <lite-youtube videoid={videoid}>
+    </lite-youtube>
+  );
+}
+
+/**
+ * Extract a YouTube ID from a string.
+ * @param idOrUrl String to test
+ * @returns A YouTube video ID or undefined if none matched
+ */
+function extractID(idOrUrl: string) {
+  const idRegExp = /^[A-Za-z0-9-_]+$/;
+  if (idRegExp.test(idOrUrl)) return idOrUrl;
+  return urlMatcher(idOrUrl);
+}
+
+/**
+ * Extract a YouTube ID from a URL if it matches the pattern.
+ * @param url URL to test
+ * @returns A YouTube video ID or undefined if none matched
+ */
+function urlMatcher(url: string): string | undefined {
+  const urlPattern =
+    /(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:\/\/)??(?:w{3}\.)??(?:youtube\.com|youtu\.be)\/(?:watch\?v=|embed\/|shorts\/)??([A-Za-z0-9-_]{11})(?:[^\s<>]*)(?=(\s*))\4(?:<\/a>)??(?=(\s*))\5/;
+  const match = url.match(urlPattern);
+  return match?.[3];
+}

--- a/learn/_components/SectionTeaser.tsx
+++ b/learn/_components/SectionTeaser.tsx
@@ -1,0 +1,15 @@
+export function SectionTeaser(
+  props: { title: string; text: string; link: string; cta: string },
+) {
+  return (
+    <div className="mt-4 text-center">
+      <h3 className="text-xl font-semibold">
+        <a href={props.link}>{props.title}</a>
+      </h3>
+      <p className="my-4">{props.text}</p>
+      <a className="homepage-link runtime-link" href={props.link}>
+        {props.cta}
+      </a>
+    </div>
+  );
+}

--- a/learn/_pages/LandingPage.tsx
+++ b/learn/_pages/LandingPage.tsx
@@ -14,15 +14,15 @@ export default function LandingPage() {
           </h1>
           <p className="max-w-prose mx-auto">
             Tutorials, videos and example code to help you go from Deno beginner
-            to expert.
+            to Deno expert.
           </p>
         </div>
-        <div className="align-middle flex flex-row gap-8">
-          <div className="w-full">
+        <div className="align-middle flex items-center gap-8 mb-20">
+          <div className="flex-1">
             <EmbedVideo id="H8VLifMOBHU" />
           </div>
-          <div className="text-center ">
-            <h2 className="text-2xl font-semibold">What is Deno?</h2>
+          <div className="flex-1 text-center">
+            <h2 className="text-2xl font-semibold ">What is Deno?</h2>
             <p className="my-4">
               Deno, is an open-source runtime for TypeScript and JavaScript.
               Features built-in dev tools, powerful platform APIs, and native
@@ -36,28 +36,34 @@ export default function LandingPage() {
             </p>
           </div>
         </div>
-        <h2 className="text-2xl mt-16 mb-8 font-semibold text-center">
+        <h2 className="text-3xl mt-20 mb-8 font-semibold text-center">
           How do you like to learn?
         </h2>
-        <div className="align-middle flex flex-row gap-8">
-          <SectionTeaser
-            title="By example"
-            text="Our examples section holds a collection of annotated Deno examples, to be used as a reference for how to build with Deno, or as a guide to learn about many of Deno's features."
-            link="/learn/examples/"
-            cta="Explore the examples"
-          />
-          <SectionTeaser
-            title="With video"
-            text="Explore our playlists of videos curated to guide you through getting the best out of using Deno for your development projects."
-            link="/learn/videos/"
-            cta="Explore the videos"
-          />
-          <SectionTeaser
-            title="Through tutorials"
-            text="Explore our playlists of videos curated to guide you through getting the best out of using Deno for your development projects."
-            link="/learn/tutorials/"
-            cta="Explore the tutorials"
-          />
+        <div className="align-middle flex flex-row gap-8 mb-20">
+          <div className="flex-1">
+            <SectionTeaser
+              title="By example"
+              text="Our examples section holds a collection of annotated Deno examples, to be used as a reference for how to build with Deno, or as a guide to learn about many of Deno's features."
+              link="/learn/examples/"
+              cta="Explore the examples"
+            />
+          </div>
+          <div className="flex-1">
+            <SectionTeaser
+              title="With video"
+              text="Explore our playlists of videos curated to guide you through getting the best out of using Deno for your development projects."
+              link="/learn/videos/"
+              cta="Explore the videos"
+            />
+          </div>
+          <div className="flex-1">
+            <SectionTeaser
+              title="Through tutorials"
+              text="Explore our playlists of videos curated to guide you through getting the best out of using Deno for your development projects."
+              link="/learn/tutorials/"
+              cta="Explore the tutorials"
+            />
+          </div>
         </div>
       </div>
     </main>

--- a/learn/_pages/LandingPage.tsx
+++ b/learn/_pages/LandingPage.tsx
@@ -18,10 +18,10 @@ export default function LandingPage() {
           </p>
         </div>
         <div className="align-middle flex flex-row gap-8">
-          <div className="w-1/2">
-            <EmbedVideo url="https://www.youtube.com/watch?v=sNzJXb6vV8o" />
+          <div className="w-full">
+            <EmbedVideo id="H8VLifMOBHU" />
           </div>
-          <div className="text-center">
+          <div className="text-center ">
             <h2 className="text-2xl font-semibold">What is Deno?</h2>
             <p className="my-4">
               Deno, is an open-source runtime for TypeScript and JavaScript.

--- a/learn/_pages/LandingPage.tsx
+++ b/learn/_pages/LandingPage.tsx
@@ -1,10 +1,65 @@
+import { SectionTeaser } from "../_components/SectionTeaser.tsx";
+import { EmbedVideo } from "../_components/EmbedVideo.tsx";
+
 export default function LandingPage() {
   return (
-    <>
-      <h1>The Learning hub page</h1>
-      <a href="/learn/examples/">Deno by Example</a>
-      <a href="/learn/tutorials/">Tutorials</a>
-      <a href="/learn/videos/">Videos</a>
-    </>
+    <main
+      id="content"
+      className="w-full flex flex-col px-8 pt-6 mt-16 md:items-center md:justify-center md:flex-row gap-0 md:gap-16 max-w-screen-xl mx-auto mb-20"
+    >
+      <div className="pb-16 align-middle md:pb-0 w-full">
+        <div className="mt-8 mb-16 md:mb-24 text-center">
+          <h1 className="text-4xl md:text-6xl font-semibold mb-4">
+            Learn Deno
+          </h1>
+          <p className="max-w-prose mx-auto">
+            Tutorials, videos and example code to help you go from Deno beginner
+            to expert.
+          </p>
+        </div>
+        <div className="align-middle flex flex-row gap-8">
+          <div className="w-1/2">
+            <EmbedVideo url="https://www.youtube.com/watch?v=sNzJXb6vV8o" />
+          </div>
+          <div className="text-center">
+            <h2 className="text-2xl font-semibold">What is Deno?</h2>
+            <p className="my-4">
+              Deno, is an open-source runtime for TypeScript and JavaScript.
+              Features built-in dev tools, powerful platform APIs, and native
+              support for TypeScript and JSX. In this video we'll introduce Deno
+              and its core concepts
+            </p>
+            <p>
+              <a className="homepage-link runtime-link" href="/learn/video/">
+                Watch the getting started video series
+              </a>
+            </p>
+          </div>
+        </div>
+        <h2 className="text-2xl mt-16 mb-8 font-semibold text-center">
+          How do you like to learn?
+        </h2>
+        <div className="align-middle flex flex-row gap-8">
+          <SectionTeaser
+            title="By example"
+            text="Our examples section holds a collection of annotated Deno examples, to be used as a reference for how to build with Deno, or as a guide to learn about many of Deno's features."
+            link="/learn/examples/"
+            cta="Explore the examples"
+          />
+          <SectionTeaser
+            title="With video"
+            text="Explore our playlists of videos curated to guide you through getting the best out of using Deno for your development projects."
+            link="/learn/videos/"
+            cta="Explore the videos"
+          />
+          <SectionTeaser
+            title="Through tutorials"
+            text="Explore our playlists of videos curated to guide you through getting the best out of using Deno for your development projects."
+            link="/learn/tutorials/"
+            cta="Explore the tutorials"
+          />
+        </div>
+      </div>
+    </main>
   );
 }

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,5 @@
+@import "./youtube-lite.css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/youtube-lite.client.js
+++ b/youtube-lite.client.js
@@ -1,0 +1,255 @@
+/**
+ * A lightweight youtube embed. Still should feel the same to the user, just MUCH faster to initialize and paint.
+ *
+ * Thx to these as the inspiration
+ *   https://storage.googleapis.com/amp-vs-non-amp/youtube-lazy.html
+ *   https://autoplay-youtube-player.glitch.me/
+ *
+ * Once built it, I also found these:
+ *   https://github.com/ampproject/amphtml/blob/master/extensions/amp-youtube (👍👍)
+ *   https://github.com/Daugilas/lazyYT
+ *   https://github.com/vb/lazyframe
+ */
+class LiteYTEmbed extends HTMLElement {
+  connectedCallback() {
+    this.videoId = this.getAttribute("videoid");
+
+    let playBtnEl = this.querySelector(".lyt-playbtn,.lty-playbtn");
+    // A label for the button takes priority over a [playlabel] attribute on the custom-element
+    this.playLabel = (playBtnEl && playBtnEl.textContent.trim()) ||
+      this.getAttribute("playlabel") || "Play";
+
+    this.dataset.title = this.getAttribute("title") || "";
+
+    /**
+     * Lo, the youtube poster image!  (aka the thumbnail, image placeholder, etc)
+     *
+     * See https://github.com/paulirish/lite-youtube-embed/blob/master/youtube-thumbnail-urls.md
+     */
+    if (!this.style.backgroundImage) {
+      this.style.backgroundImage =
+        `url("https://i.ytimg.com/vi/${this.videoId}/hqdefault.jpg")`;
+      this.upgradePosterImage();
+    }
+
+    // Set up play button, and its visually hidden label
+    if (!playBtnEl) {
+      playBtnEl = document.createElement("button");
+      playBtnEl.type = "button";
+      // Include the mispelled 'lty-' in case it's still being used. https://github.com/paulirish/lite-youtube-embed/issues/65
+      playBtnEl.classList.add("lyt-playbtn", "lty-playbtn");
+      this.append(playBtnEl);
+    }
+    if (!playBtnEl.textContent) {
+      const playBtnLabelEl = document.createElement("span");
+      playBtnLabelEl.className = "lyt-visually-hidden";
+      playBtnLabelEl.textContent = this.playLabel;
+      playBtnEl.append(playBtnLabelEl);
+    }
+
+    this.addNoscriptIframe();
+
+    // for the PE pattern, change anchor's semantics to button
+    if (playBtnEl.nodeName === "A") {
+      playBtnEl.removeAttribute("href");
+      playBtnEl.setAttribute("tabindex", "0");
+      playBtnEl.setAttribute("role", "button");
+      // fake button needs keyboard help
+      playBtnEl.addEventListener("keydown", (e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          this.activate();
+        }
+      });
+    }
+
+    // On hover (or tap), warm up the TCP connections we're (likely) about to use.
+    this.addEventListener("pointerover", LiteYTEmbed.warmConnections, {
+      once: true,
+    });
+    this.addEventListener("focusin", LiteYTEmbed.warmConnections, {
+      once: true,
+    });
+
+    // Once the user clicks, add the real iframe and drop our play button
+    // TODO: In the future we could be like amp-youtube and silently swap in the iframe during idle time
+    //   We'd want to only do this for in-viewport or near-viewport ones: https://github.com/ampproject/amphtml/pull/5003
+    this.addEventListener("click", this.activate);
+
+    // Chrome & Edge desktop have no problem with the basic YouTube Embed with ?autoplay=1
+    // However Safari desktop and most/all mobile browsers do not successfully track the user gesture of clicking through the creation/loading of the iframe,
+    // so they don't autoplay automatically. Instead we must load an additional 2 sequential JS files (1KB + 165KB) (un-br) for the YT Player API
+    // TODO: Try loading the the YT API in parallel with our iframe and then attaching/playing it. #82
+    this.needsYTApi = this.hasAttribute("js-api") ||
+      navigator.vendor.includes("Apple") ||
+      navigator.userAgent.includes("Mobi");
+  }
+
+  /**
+   * Add a <link rel={preload | preconnect} ...> to the head
+   */
+  static addPrefetch(kind, url, as) {
+    const linkEl = document.createElement("link");
+    linkEl.rel = kind;
+    linkEl.href = url;
+    if (as) {
+      linkEl.as = as;
+    }
+    document.head.append(linkEl);
+  }
+
+  /**
+   * Begin pre-connecting to warm up the iframe load
+   * Since the embed's network requests load within its iframe,
+   *   preload/prefetch'ing them outside the iframe will only cause double-downloads.
+   * So, the best we can do is warm up a few connections to origins that are in the critical path.
+   *
+   * Maybe `<link rel=preload as=document>` would work, but it's unsupported: http://crbug.com/593267
+   * But TBH, I don't think it'll happen soon with Site Isolation and split caches adding serious complexity.
+   */
+  static warmConnections() {
+    if (LiteYTEmbed.preconnected) return;
+
+    // The iframe document and most of its subresources come right off youtube.com
+    LiteYTEmbed.addPrefetch("preconnect", "https://www.youtube-nocookie.com");
+    // The botguard script is fetched off from google.com
+    LiteYTEmbed.addPrefetch("preconnect", "https://www.google.com");
+
+    // Not certain if these ad related domains are in the critical path. Could verify with domain-specific throttling.
+    LiteYTEmbed.addPrefetch(
+      "preconnect",
+      "https://googleads.g.doubleclick.net",
+    );
+    LiteYTEmbed.addPrefetch("preconnect", "https://static.doubleclick.net");
+
+    LiteYTEmbed.preconnected = true;
+  }
+
+  fetchYTPlayerApi() {
+    if (window.YT || (window.YT && window.YT.Player)) return;
+
+    this.ytApiPromise = new Promise((res, rej) => {
+      var el = document.createElement("script");
+      el.src = "https://www.youtube.com/iframe_api";
+      el.async = true;
+      el.onload = (_) => {
+        YT.ready(res);
+      };
+      el.onerror = rej;
+      this.append(el);
+    });
+  }
+
+  /** Return the YT Player API instance. (Public L-YT-E API) */
+  async getYTPlayer() {
+    if (!this.playerPromise) {
+      await this.activate();
+    }
+
+    return this.playerPromise;
+  }
+
+  async addYTPlayerIframe() {
+    this.fetchYTPlayerApi();
+    await this.ytApiPromise;
+
+    const videoPlaceholderEl = document.createElement("div");
+    this.append(videoPlaceholderEl);
+
+    const paramsObj = Object.fromEntries(this.getParams().entries());
+
+    this.playerPromise = new Promise((resolve) => {
+      let player = new YT.Player(videoPlaceholderEl, {
+        width: "100%",
+        videoId: this.videoId,
+        playerVars: paramsObj,
+        events: {
+          "onReady": (event) => {
+            event.target.playVideo();
+            resolve(player);
+          },
+        },
+      });
+    });
+  }
+
+  // Add the iframe within <noscript> for indexability discoverability. See https://github.com/paulirish/lite-youtube-embed/issues/105
+  addNoscriptIframe() {
+    const iframeEl = this.createBasicIframe();
+    const noscriptEl = document.createElement("noscript");
+    // Appending into noscript isn't equivalant for mysterious reasons: https://html.spec.whatwg.org/multipage/scripting.html#the-noscript-element
+    noscriptEl.innerHTML = iframeEl.outerHTML;
+    this.append(noscriptEl);
+  }
+
+  getParams() {
+    const params = new URLSearchParams(this.getAttribute("params") || []);
+    params.append("autoplay", "1");
+    params.append("playsinline", "1");
+    return params;
+  }
+
+  async activate() {
+    if (this.classList.contains("lyt-activated")) return;
+    this.classList.add("lyt-activated");
+
+    if (this.needsYTApi) {
+      return this.addYTPlayerIframe(this.getParams());
+    }
+
+    const iframeEl = this.createBasicIframe();
+    this.append(iframeEl);
+
+    // Set focus for a11y
+    iframeEl.focus();
+  }
+
+  createBasicIframe() {
+    const iframeEl = document.createElement("iframe");
+    iframeEl.width = 560;
+    iframeEl.height = 315;
+    // No encoding necessary as [title] is safe. https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#:~:text=Safe%20HTML%20Attributes%20include
+    iframeEl.title = this.playLabel;
+    iframeEl.allow =
+      "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture";
+    iframeEl.allowFullscreen = true;
+    // AFAIK, the encoding here isn't necessary for XSS, but we'll do it only because this is a URL
+    // https://stackoverflow.com/q/64959723/89484
+    iframeEl.src = `https://www.youtube-nocookie.com/embed/${
+      encodeURIComponent(this.videoId)
+    }?${this.getParams().toString()}`;
+    return iframeEl;
+  }
+
+  /**
+   * In the spirit of the `lowsrc` attribute and progressive JPEGs, we'll upgrade the reliable
+   * poster image to a higher resolution one, if it's available.
+   * Interestingly this sddefault webp is often smaller in filesize, but we will still attempt it second
+   * because getting _an_ image in front of the user if our first priority.
+   *
+   * See https://github.com/paulirish/lite-youtube-embed/blob/master/youtube-thumbnail-urls.md for more details
+   */
+  upgradePosterImage() {
+    // Defer to reduce network contention.
+    setTimeout(() => {
+      const webpUrl =
+        `https://i.ytimg.com/vi_webp/${this.videoId}/sddefault.webp`;
+      const img = new Image();
+      img.fetchPriority = "low"; // low priority to reduce network contention
+      img.referrerpolicy = "origin"; // Not 100% sure it's needed, but https://github.com/ampproject/amphtml/pull/3940
+      img.src = webpUrl;
+      img.onload = (e) => {
+        // A pretty ugly hack since onerror won't fire on YouTube image 404. This is (probably) due to
+        // Youtube's style of returning data even with a 404 status. That data is a 120x90 placeholder image.
+        // … per "annoying yt 404 behavior" in the .md
+        const noAvailablePoster = e.target.naturalHeight == 90 &&
+          e.target.naturalWidth == 120;
+        if (noAvailablePoster) return;
+
+        this.style.backgroundImage = `url("${webpUrl}")`;
+      };
+    }, 100);
+  }
+}
+// Register custom element
+customElements.define("lite-youtube", LiteYTEmbed);

--- a/youtube-lite.css
+++ b/youtube-lite.css
@@ -1,0 +1,102 @@
+lite-youtube {
+  background-color: #000;
+  position: relative;
+  display: block;
+  contain: content;
+  background-position: center center;
+  background-size: cover;
+  cursor: pointer;
+  max-width: 720px;
+}
+
+/* gradient */
+lite-youtube::before {
+  content: attr(data-title);
+  display: block;
+  position: absolute;
+  top: 0;
+  /* Pixel-perfect port of YT's gradient PNG, using https://github.com/bluesmoon/pngtocss plus optimizations */
+  background-image: linear-gradient(
+    180deg,
+    rgb(0 0 0 / 67%) 0%,
+    rgb(0 0 0 / 54%) 14%,
+    rgb(0 0 0 / 15%) 54%,
+    rgb(0 0 0 / 5%) 72%,
+    rgb(0 0 0 / 0%) 94%
+  );
+  height: 99px;
+  width: 100%;
+  font-family: "YouTube Noto", Roboto, Arial, Helvetica, sans-serif;
+  color: hsl(0deg 0% 93.33%);
+  text-shadow: 0 0 2px rgba(0, 0, 0, 0.5);
+  font-size: 18px;
+  padding: 25px 20px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  box-sizing: border-box;
+}
+
+lite-youtube:hover::before {
+  color: white;
+}
+
+/* responsive iframe with a 16:9 aspect ratio
+  thanks https://css-tricks.com/responsive-iframes/
+*/
+lite-youtube::after {
+  content: "";
+  display: block;
+  padding-bottom: calc(100% / (16 / 9));
+}
+lite-youtube > iframe {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  border: 0;
+}
+
+/* play button */
+lite-youtube > .lyt-playbtn {
+  display: block;
+  /* Make the button element cover the whole area for a large hover/click target… */
+  width: 100%;
+  height: 100%;
+  /* …but visually it's still the same size */
+  background: no-repeat center/68px 48px;
+  /* YT's actual play button svg */
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 68 48"><path d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z" fill="red"/><path d="M45 24 27 14v20" fill="white"/></svg>');
+  position: absolute;
+  cursor: pointer;
+  z-index: 1;
+  filter: grayscale(100%);
+  transition: filter 0.1s cubic-bezier(0, 0, 0.2, 1);
+  border: 0;
+}
+
+lite-youtube:hover > .lyt-playbtn,
+lite-youtube .lyt-playbtn:focus {
+  filter: none;
+}
+
+/* Post-click styles */
+lite-youtube.lyt-activated {
+  cursor: unset;
+}
+lite-youtube.lyt-activated::before,
+lite-youtube.lyt-activated > .lyt-playbtn {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.lyt-visually-hidden {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}


### PR DESCRIPTION
First pass at the Learn landing page.

- Adds `EmbedVideo` component (scoped to the learn section for now)
- Adds `SectionTeaser` component (scoped to the learn section for now)
- Basic layout of the Landing page

Also:
- Updates the mobile nav to remove Examples and Add Learn
- Uses "Learn" in primary nav

Still todo:
- Responsive layout of the Layout page
- Copywriting for the page
- Apply consistent containing page template for the learn section to include secondary nave