### PR TITLE
fix: add `--unstable-sql` flag to formatter options

### DIFF
--- a/runtime/fundamentals/linting_and_formatting.md
+++ b/runtime/fundamentals/linting_and_formatting.md
@@ -111,6 +111,7 @@ before being merged.
 | unstable-css       | Enable formatting CSS, SCSS, Sass and Less files       |            |                         |
 | unstable-html      | Enable formatting HTML files                           |            |                         |
 | unstable-yaml      | Enable formatting YAML files                           |            |                         |
+| unstable-sql       | Enable formatting SQL files                            |            |                         |
 | use-tabs           | Use tabs instead of spaces for indentation             | **false**  | true, false             |
 
 The formatter can be configured in a


### PR DESCRIPTION
This pull request introduces the addition of the `--unstable-sql` flag, as introduced in https://github.com/denoland/deno/pull/26750, to the options of the formatter.