### PR TITLE
chore: prevent button text from wrapping

### DIFF
--- a/index.page.tsx
+++ b/index.page.tsx
@@ -52,7 +52,7 @@ export default function () {
             </p>
             {/* CTA Group */}
 
-            <div class="flex flex-row gap-4 mt-8">
+            <div class="flex flex-row flex-wrap gap-4 mt-8">
               <DocsCTA
                 text="Get Started"
                 href="/runtime/"


### PR DESCRIPTION
Prevent text inside buttons from wrapping on iPhone SE.

Current:
![image](https://github.com/user-attachments/assets/38bc30a8-ed6c-4044-b625-01cc46a9eb40)

This PR:
![image](https://github.com/user-attachments/assets/406a6b49-23e3-4daa-9f09-f01ecb27f071)
