### PR TITLE
docs(examples): add example for spy functions

### DIFF
--- a/examples/spy-functions.ts
+++ b/examples/spy-functions.ts
@@ -14,36 +14,36 @@
 import { assertSpyCall, assertSpyCalls, spy } from "jsr:@std/testing/mock";
 
 function log(message: string) {
-    console.log(message);
+  console.log(message);
 }
 
 const logger = { log };
 
 Deno.test("logger uses the log function", () => {
-    // Create a spy on the `logger.log` method.
-    const logSpy = spy(logger, "log");
+  // Create a spy on the `logger.log` method.
+  const logSpy = spy(logger, "log");
 
-    // Call the `logger.log` method.
-    logger.log("Hello, world!");
+  // Call the `logger.log` method.
+  logger.log("Hello, world!");
 
-    try {
-        // Assert that the `log` function was called just once.
-        assertSpyCalls(logSpy, 1);
+  try {
+    // Assert that the `log` function was called just once.
+    assertSpyCalls(logSpy, 1);
 
-        // Assert that the `log` function was called with the correct arguments.
-        assertSpyCall(logSpy, 0, { args: ["Hello, world!"] });
-    } finally {
-        // Restore the logger.log function to stop spying it.
-        logSpy.restore();
-    }
+    // Assert that the `log` function was called with the correct arguments.
+    assertSpyCall(logSpy, 0, { args: ["Hello, world!"] });
+  } finally {
+    // Restore the logger.log function to stop spying it.
+    logSpy.restore();
+  }
 });
 
 Deno.test("Creating a spy with the using keyword", () => {
-    // method spies are disposable, so we can create them with the keyword `using`
-    using logSpy = spy(logger, "log");
+  // method spies are disposable, so we can create them with the keyword `using`
+  using logSpy = spy(logger, "log");
 
-    logger.log("Disposable spy");
+  logger.log("Disposable spy");
 
-    // Spies created with the `using` keyword are automatically restored at the end of the test
-    assertSpyCalls(logSpy, 1);
+  // Spies created with the `using` keyword are automatically restored at the end of the test
+  assertSpyCalls(logSpy, 1);
 });

--- a/examples/spy-functions.ts
+++ b/examples/spy-functions.ts
@@ -39,11 +39,11 @@ Deno.test("logger uses the log function", () => {
 });
 
 Deno.test("Creating a spy with the using keyword", () => {
-  // method spies are disposable, so we can create them with the keyword `using`
+  // method spys are disposable, so we can create them with the keyword `using`
   using logSpy = spy(logger, "log");
 
   logger.log("Disposable spy");
 
-  // Spies created with the `using` keyword are automatically restored at the end of the test
+  // Spys created with the `using` keyword are automatically restored at the end of the test
   assertSpyCalls(logSpy, 1);
 });

--- a/examples/spy-functions.ts
+++ b/examples/spy-functions.ts
@@ -1,0 +1,49 @@
+/**
+ * @title Spy functions
+ * @difficulty intermediate
+ * @tags cli, deploy
+ * @run <url>
+ * @resource {https://jsr.io/@std/testing/doc/mock#spying} Spy docs on JSR
+ * @resource {https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html} Typescript docs for `using` keyword
+ * @group Testing
+ *
+ * A function spy allow us to assert that a function was called with the correct arguments and a specific number of times.
+ * This snippet demonstrates how to spy on a function using a mock function.
+ */
+
+import { assertSpyCall, assertSpyCalls, spy } from "jsr:@std/testing/mock";
+
+function log(message: string) {
+    console.log(message);
+}
+
+const logger = { log };
+
+Deno.test("logger uses the log function", () => {
+    // Create a spy on the `logger.log` method.
+    const logSpy = spy(logger, "log");
+
+    // Call the `logger.log` method.
+    logger.log("Hello, world!");
+
+    try {
+        // Assert that the `log` function was called just once.
+        assertSpyCalls(logSpy, 1);
+
+        // Assert that the `log` function was called with the correct arguments.
+        assertSpyCall(logSpy, 0, { args: ["Hello, world!"] });
+    } finally {
+        // Restore the logger.log function to stop spying it.
+        logSpy.restore();
+    }
+});
+
+Deno.test("Creating a spy with the using keyword", () => {
+    // method spies are disposable, so we can create them with the keyword `using`
+    using logSpy = spy(logger, "log");
+
+    logger.log("Disposable spy");
+
+    // Spies created with the `using` keyword are automatically restored at the end of the test
+    assertSpyCalls(logSpy, 1);
+});


### PR DESCRIPTION
Hello deno community!
I added an example for how to spy on functions using `std@testing/mock`

Related to issue #1088 

I wasn't sure in which group put this example so I kinda created a new group for 'Testing'. I want to upload another example on how to use stubs. It seems like the group should be created elsewhere in order to appear as a correct group (titlecase), I would really appreciate little help on this :)