### PR TITLE
add some margin between snippets in examples

### DIFF
--- a/examples.page.tsx
+++ b/examples.page.tsx
@@ -313,7 +313,7 @@ function SnippetComponent(props: {
     <div class="grid grid-cols-1 sm:grid-cols-10 gap-x-8">
       <div
         class={`italic select-none text-sm ${
-          props.snippet.text ? "pb-4 md:pb-0 " : " "
+          props.snippet.text ? "mb-4" : " "
         } ${props.snippet.code ? "col-span-3" : "mt-4 col-span-full"}`}
       >
         {props.snippet.text}


### PR DESCRIPTION
mainly to resolve the snippet without code combining with the snippet below. Resolves #1003