### PR TITLE
Fix runtime link contrast on homepage

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -287,8 +287,8 @@ body {
 }
 
 .runtime-link {
-  @apply text-runtime-600 decoration-runtime-600/20
-    hover:decoration-runtime-600;
+  @apply dark:text-runtime dark:decoration-runtime dark:hover:text-runtime-600 dark:hover:decoration-runtime-600 decoration-1
+    text-runtime-800 decoration-runtime-800 hover:decoration-runtime-600 hover:text-runtime-600 transition-colors duration-100
 }
 
 .help-link {

--- a/styles.css
+++ b/styles.css
@@ -287,8 +287,10 @@ body {
 }
 
 .runtime-link {
-  @apply dark:text-runtime dark:decoration-runtime dark:hover:text-runtime-600 dark:hover:decoration-runtime-600 decoration-1
-    text-runtime-800 decoration-runtime-800 hover:decoration-runtime-600 hover:text-runtime-600 transition-colors duration-100
+  @apply dark:text-runtime dark:decoration-runtime dark:hover:text-runtime-600
+    dark:hover:decoration-runtime-600 decoration-1 text-runtime-800
+    decoration-runtime-800 hover:decoration-runtime-600 hover:text-runtime-600
+    transition-colors duration-100;
 }
 
 .help-link {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -39,7 +39,7 @@ export default {
           "100": "#d6ffe1",
           "200": "#b3ffcd",
           "300": "#70ffae",
-          DEFAULT: "70ffae",
+          DEFAULT: "#70ffae",
           "400": "#32f59a",
           "500": "#09dc8b",
           "600": "#01b780",


### PR DESCRIPTION
Fixes the link colors on the homepage (and occasionally elsewhere) being too light/dark to contrast properly for a11y requirements.