### PR TITLE
fix: type safety for yaml parsed file

### DIFF
--- a/runtime/_data.ts
+++ b/runtime/_data.ts
@@ -292,7 +292,7 @@ export async function generateDescriptions(): Promise<Descriptions> {
     )
   ) {
     const file = await Deno.readTextFile(dirEntry.path);
-    const parsed = yamlParse(file);
+    const parsed = yamlParse(file) as DescriptionItem;
     if (!parsed) {
       throw `Invalid or empty file: ${dirEntry.path}`;
     }


### PR DESCRIPTION
`parsed` is now casted to `DescriptionItem` instead of being `unknown`