### PR TITLE
Move examples page; fix CSS color issues

### DIFF
--- a/_components/LandingPage.tsx
+++ b/_components/LandingPage.tsx
@@ -1,8 +1,8 @@
-import { ExampleIcon } from "../_components/ExampleIcon.tsx";
-import { LearningList } from "../_components/LearningList.tsx";
-import { TutorialIcon } from "../_components/TutorialIcon.tsx";
-import { VideoIcon } from "../_components/VideoIcon.tsx";
-import { sidebar } from "../_data.ts";
+import { ExampleIcon } from "../examples/_components/ExampleIcon.tsx";
+import { LearningList } from "../examples/_components/LearningList.tsx";
+import { TutorialIcon } from "../examples/_components/TutorialIcon.tsx";
+import { VideoIcon } from "../examples/_components/VideoIcon.tsx";
+import { sidebar } from "../examples/_data.ts";
 
 export default function LandingPage() {
   const componentsPerSidebarItem = sidebar.map(

--- a/deno.lock
+++ b/deno.lock
@@ -51,6 +51,7 @@
     "npm:@supabase/node-fetch@2.6.15": "2.6.15",
     "npm:@supabase/postgrest-js@1.16.3": "1.16.3",
     "npm:@supabase/realtime-js@2.10.7": "2.10.7",
+    "npm:@supabase/realtime-js@2.11.2": "2.11.2",
     "npm:@supabase/storage-js@2.7.1": "2.7.1",
     "npm:@types/estree@1.0.6": "1.0.6",
     "npm:@types/node@*": "22.5.4",
@@ -301,6 +302,15 @@
     },
     "@supabase/realtime-js@2.10.7": {
       "integrity": "sha512-OLI0hiSAqQSqRpGMTUwoIWo51eUivSYlaNBgxsXZE7PSoWh12wPRdVt0psUMaUzEonSB85K21wGc7W5jHnT6uA==",
+      "dependencies": [
+        "@supabase/node-fetch",
+        "@types/phoenix",
+        "@types/ws",
+        "ws"
+      ]
+    },
+    "@supabase/realtime-js@2.11.2": {
+      "integrity": "sha512-u/XeuL2Y0QEhXSoIPZZwR6wMXgB+RQbJzG9VErA3VghVt7uRfSVsjeqd7m5GhX3JR6dM/WRmLbVR8URpDWG4+w==",
       "dependencies": [
         "@supabase/node-fetch",
         "@types/phoenix",

--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -1,5 +1,3 @@
-import LandingPage from "./_pages/LandingPage.tsx";
-
 export const layout = "raw.tsx";
 export const sidebar = [
   {
@@ -30,10 +28,12 @@ export const sidebar = [
 
 export const toc = [];
 
-export default function* (_data: Lume.Data, helpers: Lume.Helpers) {
+export default function* (
+  data: Lume.Data,
+) {
   yield {
     url: `/examples/`,
     title: `Deno examples and tutorials`,
-    content: <LandingPage />,
+    content: <data.comp.LandingPage />,
   };
 }

--- a/styles.css
+++ b/styles.css
@@ -11,8 +11,8 @@
 /* Light and dark theme variables */
 .light {
   --background-primary: 215deg, 81%, 100%;
-  --background-secondary: 213deg, 100% 95%;
-  --background-tertiary: 213deg, 100% 84%;
+  --background-secondary: 213deg, 100%, 95%;
+  --background-tertiary: 213deg, 100%, 84%;
   --foreground-primary: 0deg, 0%, 25%;
   --foreground-secondary: 0deg, 0%, 42%;
   --foreground-tertiary: 0deg, 0%, 90%;


### PR DESCRIPTION
- Moves the /examples `LandingPage` component into the `_components` folder so that it auto-refreshes when changes are made locally
- Fixes some CSS color values that were previously missing commas, rendering them as white

![CleanShot 2024-12-11 at 09 34 55@2x](https://github.com/user-attachments/assets/c1e5a2aa-10db-4840-a6db-f5c35917440c)

<img width="1277" alt="image" src="https://github.com/user-attachments/assets/f01eb96f-c957-4dcf-9277-ed8827a0bfa3" />
