### PR TITLE
Replace @deno-types with @ts-types

### DIFF
--- a/examples/tutorials/express.md
+++ b/examples/tutorials/express.md
@@ -26,7 +26,7 @@ touch main.ts
 In `main.ts`, let's create a simple server:
 
 ```ts
-// @deno-types="npm:@types/express@4.17.15"
+// @ts-types="npm:@types/express@4.17.15"
 import express from "npm:express@4.18.2";
 
 const app = express();

--- a/runtime/fundamentals/node.md
+++ b/runtime/fundamentals/node.md
@@ -299,13 +299,12 @@ import chalk from "npm:chalk@5";
 ```
 
 Some packages do not ship with types but you can specify their types with the
-[`@deno-types`](/runtime/fundamentals/typescript) directive. For example, using
-a
+[`@ts-types`](/runtime/fundamentals/typescript) directive. For example, using a
 [`@types`](https://www.typescriptlang.org/docs/handbook/2/type-declarations.html#definitelytyped--types)
 package:
 
 ```ts
-// @deno-types="npm:@types/express@^4.17"
+// @ts-types="npm:@types/express@^4.17"
 import express from "npm:express@^4.17";
 ```
 


### PR DESCRIPTION
`@ts-types` is now the recommended way to add types to js imports. ref https://github.com/denoland/docs/pull/502

This PR replaces the use of `@deno-types` with `@ts-types`.

(These `@deno-types` usages were pointed in https://github.com/denoland/deno/issues/27309#issuecomment-2535862020