### PR TITLE
fix: add `unsafe-proto` flag to run Next.js app

### DIFF
--- a/examples/tutorials/next.md
+++ b/examples/tutorials/next.md
@@ -41,6 +41,15 @@ to install the dependencies
 deno install
 ```
 
+Next.js has some dependencies that still rely on `Object.prototype.__proto__`, so you need to allow it first.
+In a new `deno.json` file, add the following lines:
+
+```json deno.json
+{
+  "unstable": ["unsafe-proto"]
+}
+```
+
 Now you can serve your new Next.js app:
 
 ```sh

--- a/examples/tutorials/next.md
+++ b/examples/tutorials/next.md
@@ -42,8 +42,7 @@ deno install
 ```
 
 Next.js has some dependencies that still rely on `Object.prototype.__proto__`,
-so you need to allow it. In a new `deno.json` file, add the following
-lines:
+so you need to allow it. In a new `deno.json` file, add the following lines:
 
 ```json deno.json
 {

--- a/examples/tutorials/next.md
+++ b/examples/tutorials/next.md
@@ -41,8 +41,9 @@ to install the dependencies
 deno install
 ```
 
-Next.js has some dependencies that still rely on `Object.prototype.__proto__`, so you need to allow it first.
-In a new `deno.json` file, add the following lines:
+Next.js has some dependencies that still rely on `Object.prototype.__proto__`,
+so you need to allow it. In a new `deno.json` file, add the following
+lines:
 
 ```json deno.json
 {


### PR DESCRIPTION
As discussed in [#26584](https://github.com/denoland/deno/issues/26584), Next.js doesn't work properly unless using `--unstable-unsafe-proto`.

Using it from CLI isn't possible, so adding it to a `deno.json` file alongside the existing `package.json` is a working fix.