### PR TITLE
Restore note about @deno-types

### DIFF
--- a/runtime/reference/ts_config_migration.md
+++ b/runtime/reference/ts_config_migration.md
@@ -277,7 +277,6 @@ examining the JavaScript file.
 
 > ℹ️ _Note_: In the past the `@ts-types` directive was called `@deno-types`.
 > This alias still works, but is not recommended anymore. Use `@ts-types`.
-> `@ts-types`. This is not recommended anymore.
 
 ## Providing types when hosting
 

--- a/runtime/reference/ts_config_migration.md
+++ b/runtime/reference/ts_config_migration.md
@@ -279,7 +279,8 @@ The compiler hint pattern-matching is quite flexible, it accepts both quoted and
 non-quoted values for the specifier, as well as any whitespace around the equals
 sign.
 
-> ℹ️ _Note_: In the past the `@ts-types` directive was called `@deno-types`. This alias still works, but is not recommended anymore. Use `@ts-types`.
+> ℹ️ _Note_: In the past the `@ts-types` directive was called `@deno-types`.
+> This alias still works, but is not recommended anymore. Use `@ts-types`.
 > `@ts-types`. This is not recommended anymore.
 
 ## Providing types when hosting

--- a/runtime/reference/ts_config_migration.md
+++ b/runtime/reference/ts_config_migration.md
@@ -279,7 +279,7 @@ The compiler hint pattern-matching is quite flexible, it accepts both quoted and
 non-quoted values for the specifier, as well as any whitespace around the equals
 sign.
 
-> ℹ️ _Note_: The directive `@deno-types` can be used as an alias for
+> ℹ️ _Note_: In the past the `@ts-types` directive was called `@deno-types`. This alias still works, but is not recommended anymore. Use `@ts-types`.
 > `@ts-types`. This is not recommended anymore.
 
 ## Providing types when hosting

--- a/runtime/reference/ts_config_migration.md
+++ b/runtime/reference/ts_config_migration.md
@@ -279,6 +279,9 @@ The compiler hint pattern-matching is quite flexible, it accepts both quoted and
 non-quoted values for the specifier, as well as any whitespace around the equals
 sign.
 
+> ℹ️ _Note_: The directive `@deno-types` can be used as an alias for
+> `@ts-types`. This is not recommended anymore.
+
 ## Providing types when hosting
 
 If you have control over the module’s source code or how the file is hosted on a

--- a/runtime/reference/ts_config_migration.md
+++ b/runtime/reference/ts_config_migration.md
@@ -275,10 +275,6 @@ When you’re performing type checking on `coolLib` and using it in your file, t
 TypeScript type definitions from `coolLib.d.ts` will take precedence over
 examining the JavaScript file.
 
-The compiler hint pattern-matching is quite flexible, it accepts both quoted and
-non-quoted values for the specifier, as well as any whitespace around the equals
-sign.
-
 > ℹ️ _Note_: In the past the `@ts-types` directive was called `@deno-types`.
 > This alias still works, but is not recommended anymore. Use `@ts-types`.
 > `@ts-types`. This is not recommended anymore.

--- a/runtime/reference/ts_config_migration.md
+++ b/runtime/reference/ts_config_migration.md
@@ -277,9 +277,8 @@ examining the JavaScript file.
 
 :::note
 
-In the past the `@ts-types` directive was called `@deno-types`.
-This alias still works, but is not recommended anymore. 
-Use `@ts-types`.
+In the past the `@ts-types` directive was called `@deno-types`. This alias still
+works, but is not recommended anymore. Use `@ts-types`.
 
 :::
 

--- a/runtime/reference/ts_config_migration.md
+++ b/runtime/reference/ts_config_migration.md
@@ -275,8 +275,12 @@ When you’re performing type checking on `coolLib` and using it in your file, t
 TypeScript type definitions from `coolLib.d.ts` will take precedence over
 examining the JavaScript file.
 
-> ℹ️ _Note_: In the past the `@ts-types` directive was called `@deno-types`.
-> This alias still works, but is not recommended anymore. Use `@ts-types`.
+:::note
+
+In the past the `@ts-types` directive was called `@deno-types`.
+This alias still works, but is not recommended anymore. Use `@ts-types`.
+
+:::
 
 ## Providing types when hosting
 

--- a/runtime/reference/ts_config_migration.md
+++ b/runtime/reference/ts_config_migration.md
@@ -278,7 +278,8 @@ examining the JavaScript file.
 :::note
 
 In the past the `@ts-types` directive was called `@deno-types`.
-This alias still works, but is not recommended anymore. Use `@ts-types`.
+This alias still works, but is not recommended anymore. 
+Use `@ts-types`.
 
 :::
 


### PR DESCRIPTION
This note was added in https://github.com/denoland/docs/pull/502, but removed by https://github.com/denoland/docs/pull/826 (probably by mistake?)

This note addresses the question like https://github.com/denoland/deno/issues/27309#issuecomment-2535862020