### PR TITLE
docs: update benchmark file reading example

### DIFF
--- a/runtime/reference/cli/bench.md
+++ b/runtime/reference/cli/bench.md
@@ -117,7 +117,8 @@ Deno.bench("foo", async (b) => {
 });
 ```
 
-The above example requires the `--allow-read` flag to run the benchmark: `deno bench file_reading.ts --allow-read`.
+The above example requires the `--allow-read` flag to run the benchmark:
+`deno bench --allow-read file_reading.ts`.
 
 ## Grouping and baselines
 

--- a/runtime/reference/cli/bench.md
+++ b/runtime/reference/cli/bench.md
@@ -103,7 +103,7 @@ will be excluded from the measurement.
 ```ts
 Deno.bench("foo", async (b) => {
   // Open a file that we will act upon.
-  const file = await Deno.open("a_big_data_file.txt");
+  using file = await Deno.open("a_big_data_file.txt");
 
   // Tell the benchmarking tool that this is the only section you want
   // to measure.
@@ -114,12 +114,10 @@ Deno.bench("foo", async (b) => {
 
   // End measurement here.
   b.end();
-
-  // Now we can perform some potentially time-consuming teardown that will not
-  // taint out benchmark results.
-  file.close();
 });
 ```
+
+The above example requires the `--allow-read` flag to run the benchmark: `deno bench file_reading.ts --allow-read`.
 
 ## Grouping and baselines
 


### PR DESCRIPTION
The current example in the benchmark documentation about _file reading_ breaks in the `file.close()` line. Also, I updated to include an example below of the _file reading_ bench saying that this benchmark needs the `allow-read` flag.

![CleanShot 2024-12-15 at 15 52 39@2x](https://github.com/user-attachments/assets/4072de10-c110-49c4-bbcd-449daeec95c0)
