### PR TITLE
Fix broken link to "Build a Fresh app" tutorial

### DIFF
--- a/examples/_data.ts
+++ b/examples/_data.ts
@@ -218,8 +218,7 @@ export const sidebar = [
       },
       {
         label: "Build a Fresh app",
-        id:
-          "https://fresh.deno.dev/docs/getting-started/create-a-project",
+        id: "https://fresh.deno.dev/docs/getting-started/create-a-project",
         type: "tutorial",
       },
       {

--- a/examples/_data.ts
+++ b/examples/_data.ts
@@ -219,7 +219,7 @@ export const sidebar = [
       {
         label: "Build a Fresh app",
         id:
-          "https://fresh.deno.dev/docs/getting-started/create-a-projec-tutorialt",
+          "https://fresh.deno.dev/docs/getting-started/create-a-project",
         type: "tutorial",
       },
       {


### PR DESCRIPTION
Removed what appears to be a misplaced "-tutorial" inside of the word "project."