### PR TITLE
Optimize search results

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -211,11 +211,10 @@ site.process([".html"], (pages) => {
 
 const ORAMA_API_KEY = Deno.env.get("ORAMA_CLOUD_API_KEY");
 const ORAMA_INDEX_ID = Deno.env.get("ORAMA_CLOUD_INDEX_ID");
+
 if (ORAMA_API_KEY && ORAMA_INDEX_ID) {
   site.process([".html"], async (pages) => {
     let pageEntries: OramaDocument[] = [];
-
-    await oramaClear(ORAMA_API_KEY, ORAMA_INDEX_ID);
 
     for (const page of pages) {
       if (
@@ -228,7 +227,14 @@ if (ORAMA_API_KEY && ORAMA_INDEX_ID) {
       }
     }
 
-    await oramaNotify(ORAMA_API_KEY, ORAMA_INDEX_ID, pageEntries, "pages");
+    await oramaClear(ORAMA_API_KEY, ORAMA_INDEX_ID);
+
+    console.log('Pushing', pageEntries.length, 'pages to Orama');
+    const chunkSize = 100;
+    for (let i = 0; i < pageEntries.length; i += chunkSize) {
+      const chunk = pageEntries.slice(i, i + chunkSize);
+      await oramaNotify(ORAMA_API_KEY, ORAMA_INDEX_ID, chunk, "pages");
+    }
 
     await oramaNotify(
       ORAMA_API_KEY,

--- a/search.client.ts
+++ b/search.client.ts
@@ -110,6 +110,18 @@ document.addEventListener("DOMContentLoaded", () => {
       "How to configure?",
       "How to deploy?",
     ];
+
+    oramaSearchBox.searchParams = {
+      boost: {
+        "content": 100,
+        "section": 900,
+        "parent_H2.section": 700,
+        "title": 1_000,
+        "parent_H2.content": 1,
+        "parent_H1.content": 1,
+      },
+      properties: ["title", "section", "content", "parent_H2.section", "parent_H2.content"],
+    }
   }
 
   const oramaSearchButton: OramaJSX.OramaSearchButton | null = document


### PR DESCRIPTION
In this PR:
- the orama schema changed into 
```json
{
  "path": "string",
  "title": "string",
  "content": "string",
  "section": "string",
  "category": "enum",
  "parent_H1": {
    "content": "string",
    "section": "string"
  },
  "parent_H2": {
    "content": "string",
    "section": "string"
  }
}
```
- every document also contains the "parent" context (ie, title and content)
- the search uses the `boost` parameter
