### PR TITLE
chore: replace lint.deno.land with /lint/ page

### DIFF
--- a/lint/rules/ban-unknown-rule-code.md
+++ b/lint/rules/ban-unknown-rule-code.md
@@ -5,8 +5,8 @@ tags: [recommended]
 Warns the usage of unknown rule codes in ignore directives.
 
 We sometimes have to suppress and ignore lint errors for some reasons. We can do
-so using [ignore directives](https://lint.deno.land/ignoring-rules) with rule
-names that should be ignored like so:
+so using [ignore directives](/go/lint-ignore/) with rule names that should be
+ignored like so:
 
 ```typescript
 // deno-lint-ignore no-explicit-any no-unused-vars

--- a/lint/rules/ban-unused-ignore.md
+++ b/lint/rules/ban-unused-ignore.md
@@ -5,7 +5,7 @@ tags: [recommended]
 Warns unused ignore directives.
 
 We sometimes have to suppress and ignore lint errors for some reasons and we can
-do so using [ignore directives](https://lint.deno.land/ignoring-rules).
+do so using [ignore directives](/go/lint-ignore/).
 
 In some cases, however, like after refactoring, we may end up having ignore
 directives that are no longer necessary. Such superfluous ignore directives are

--- a/lint/rules/prefer-const.md
+++ b/lint/rules/prefer-const.md
@@ -17,8 +17,8 @@ write buggy code. So this lint rule checks if there are [`let`] variables that
 could potentially be declared with [`const`] instead.
 
 Note that this rule does not check for [`var`] variables. Instead,
-[the `no-var` rule](https://lint.deno.land/rules/no-var) is responsible for
-detecting and warning [`var`] variables.
+[the `no-var` rule](/lint/rules/no-var) is responsible for detecting and warning
+[`var`] variables.
 
 [`let`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let
 [`const`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const

--- a/runtime/fundamentals/configuration.md
+++ b/runtime/fundamentals/configuration.md
@@ -201,7 +201,7 @@ This configuration will:
 - removes the `no-unused-vars` rule excluded.
 
 You can find a full list of available linting rules in the
-[Deno lint documentation](https://lint.deno.land/).
+[List of rules](/lint/) documentation page.
 
 Read more about [linting with Deno](/runtime/reference/cli/linter/).
 

--- a/runtime/fundamentals/linting_and_formatting.md
+++ b/runtime/fundamentals/linting_and_formatting.md
@@ -44,7 +44,7 @@ The linter can be configured in a
 rules, plugins, and settings to tailor the linting process to your needs.
 
 You can view and search the list of available rules and their usage on
-[Deno lint rules](https://lint.deno.land/).
+[List of rules](/lint/) documentation page.
 
 ## Formatting
 

--- a/runtime/fundamentals/node.md
+++ b/runtime/fundamentals/node.md
@@ -511,7 +511,7 @@ error[no-process-globals]: NodeJS process global is discouraged in Deno
   |             ^^^^^^^
   = hint: Add `import process from "node:process";`
 
-  docs: https://lint.deno.land/rules/no-process-globals
+  docs: https://docs.deno.com/lint/rules/no-process-globals
 
 
 Found 1 problem (1 fixable via --fix)
@@ -674,7 +674,7 @@ error[no-constant-condition]: Use of a constant expressions as conditions is not
   |     ^^^^
   = hint: Remove the constant expression
 
-  docs: https://lint.deno.land/rules/no-constant-condition
+  docs: https://docs.deno.com/lint/rules/no-constant-condition
 
 
 Found 1 problem
@@ -688,8 +688,8 @@ deno lint --fix
 ```
 
 A full list of all supported linting rules can be found on
-[https://lint.deno.land/](https://lint.deno.land/). To learn more about how to
-configure the linter, check out the
+[https://docs.deno.com/lint/](https://docs.deno.com/lint/). To learn more about
+how to configure the linter, check out the
 [`deno lint` subcommand](/runtime/reference/cli/linter/).
 
 **Formatting**

--- a/runtime/reference/cli/lint.md
+++ b/runtime/reference/cli/lint.md
@@ -11,7 +11,7 @@ command: lint
 ## Available rules
 
 For a complete list of supported rules, visit
-[the deno_lint rule documentation](https://lint.deno.land).
+[List of rules](https://docs.deno.com/lint/) documentation page.
 
 ## Ignore directives
 

--- a/runtime/reference/deno_namespace_apis.md
+++ b/runtime/reference/deno_namespace_apis.md
@@ -827,7 +827,7 @@ A couple notes on this example:
 
 - `addEventListener` and `onload`/`onunload` are prefixed with `globalThis`, but
   you could also use `self` or no prefix at all.
-  [It is not recommended to use `window` as a prefix](https://lint.deno.land/#no-window-prefix).
+  [It is not recommended to use `window` as a prefix](https://docs.deno.com/lint/rules/no-window-prefix).
 - You can use `addEventListener` and/or `onload`/`onunload` to define handlers
   for events. There is a major difference between them, let's run the example:
 


### PR DESCRIPTION
Towards migration of https://github.com/denoland/deno_lint/pull/1380