### PR TITLE
docs: add npm installation instructions for Deno

### DIFF
--- a/runtime/getting_started/installation.md
+++ b/runtime/getting_started/installation.md
@@ -160,6 +160,12 @@ You can also build and install from source using
 cargo install deno --locked
 ```
 
+Or install it using [npm](https://npmjs.com/package/deno):
+
+```shell
+npm install -g deno
+```
+
 Deno binaries can also be installed manually, by downloading a zip file at
 [github.com/denoland/deno/releases](https://github.com/denoland/deno/releases).
 These packages contain just a single executable file. You will have to set the


### PR DESCRIPTION
**Description:**

With the arrival of Deno to npm it would be great to indicate in the documentation that this installation alternative exists, thank you for taking the time.

**Preview**
<img width="1057" alt="image" src="https://github.com/user-attachments/assets/e2015309-bab2-487c-9227-afdf126d5477" />
