### PR TITLE
remove max-width on feedback and page nav

### DIFF
--- a/_components/Feedback.tsx
+++ b/_components/Feedback.tsx
@@ -8,7 +8,7 @@ export default function Feedback({ file }) {
         id="feedback-section"
         class="flex flex-col mt-12 gap-2 p-4 border border-blue-100
       dark:border-background-tertiary bg-blue-50 dark:bg-background-secondary
-      rounded max-w-[66ch] mx-auto"
+      rounded mx-auto"
       >
         <h2 class="text-xl border-b border-blue-100 dark:border-background-tertiary
         mb-2 pb-2 font-normal">

--- a/_includes/doc.tsx
+++ b/_includes/doc.tsx
@@ -163,7 +163,7 @@ export default function Page(props: Lume.Data, helpers: Lume.Helpers) {
               </div>
             </article>
             {parentNavigation && (
-              <nav class="grid gap-8 grid-cols-2 max-w-[66ch] items-center justify-between mt-12 mx-auto">
+              <nav class="grid gap-8 grid-cols-2 items-center justify-between mt-12 mx-auto">
                 <div>
                   {parentNavigation[index! - 1] && (
                     <NavigationButton


### PR DESCRIPTION
we've expanded the max width on the rest of the content so it probably makes sense to let the feedback module and page navigation expand to the same width so they aren't oddly centered under some wider content.


Old:
<img width="930" alt="Screenshot 2025-01-02 at 4 28 17 PM" src="https://github.com/user-attachments/assets/d1d7d047-34dc-475f-a955-8e0f52b57410" />

New:
<img width="874" alt="Screenshot 2025-01-02 at 4 28 50 PM" src="https://github.com/user-attachments/assets/465a9ef0-a3ca-4063-9df5-638fcb39b4f1" />
