### PR TITLE
request constructor use same name as parameters description

### DIFF
--- a/deploy/api/runtime-request.md
+++ b/deploy/api/runtime-request.md
@@ -18,7 +18,7 @@ interface is part of the Fetch API and represents the request of fetch().
 The Request() constructor creates a new Request instance.
 
 ```ts
-let request = new Request(input, init);
+let request = new Request(resource, init);
 ```
 
 #### Parameters


### PR DESCRIPTION
In one place it is called `input` whereas in the other it is called `resource`:

![Screenshot 2025-01-06 at 12 36 27](https://github.com/user-attachments/assets/0abbf2d5-8f0e-4ec7-99e1-c09f982a66b6)
