### PR TITLE
Edit language to remove reference to future date, which is now past

### DIFF
--- a/runtime/fundamentals/stability_and_releases.md
+++ b/runtime/fundamentals/stability_and_releases.md
@@ -32,7 +32,7 @@ Deno offers 4 release channels
 
 ### Long Term Support (LTS)
 
-Starting with Deno v2.1.0 (to be released in November 2024) Deno will offer a
+Starting with Deno v2.1.0 (released in November 2024) Deno offers a
 LTS (long-term support) channel.
 
 An LTS channel is a semver minor version that we maintain with only backwards

--- a/runtime/fundamentals/stability_and_releases.md
+++ b/runtime/fundamentals/stability_and_releases.md
@@ -32,8 +32,8 @@ Deno offers 4 release channels
 
 ### Long Term Support (LTS)
 
-Starting with Deno v2.1.0 (released in November 2024) Deno offers a
-LTS (long-term support) channel.
+Starting with Deno v2.1.0 (released in November 2024) Deno offers a LTS
+(long-term support) channel.
 
 An LTS channel is a semver minor version that we maintain with only backwards
 compatible bug fixes.


### PR DESCRIPTION
We refer to the release date of v2.1 as if it were in the future, but that date has now past.
This edit removes the reference to the date being in the future on this page:

https://docs.deno.com/runtime/fundamentals/stability_and_releases/#long-term-support-(lts)