### PR TITLE
fix: add redirect to old url for compile docs

### DIFF
--- a/runtime/reference/cli/compile.md
+++ b/runtime/reference/cli/compile.md
@@ -1,6 +1,7 @@
 ---
 title: "`deno compile`, standalone executables"
 oldUrl:
+ - /runtime/manual/tools/compile/
  - /runtime/manual/tools/compiler/
  - /runtime/reference/cli/compiler/
 command: compile


### PR DESCRIPTION
The go URL still points to the old URL, but a redirect is not in place. Since `deno compile --help` using the go URL, it is linking to a 404.

This was likely broken with #1182, when the go URL was changed, but a redirect was not added for the destination, missing that the new URL also needed a redirect.

Tested locally by visiting the `/runtime/manual/tools/compile` and `/go/compile`. 404 before, working after.