### PR TITLE
fix: Update task.md to fix error with package name

### DIFF
--- a/runtime/reference/cli/task.md
+++ b/runtime/reference/cli/task.md
@@ -192,8 +192,8 @@ directories in parallel. To execute `dev` tasks from all workspace members use
 
 ```jsonc title="client/deno.json"
 {
+  "name": "@scope/client",
   "tasks": {
-    "name": "@scope/client",
     "dev": "deno run -RN build.ts"
   }
 }
@@ -201,8 +201,8 @@ directories in parallel. To execute `dev` tasks from all workspace members use
 
 ```jsonc title="server/deno.json"
 {
+  "name": "@scope/server",
   "tasks": {
-    "name": "@scope/server",
     "dev": "deno run -RN server.ts"
   }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/11e7f867-ec6f-4b10-908a-a2193f8c87bd)

For deno workspaces name is expected to be in the tasks? or should it be a the top level in the deno.json?