### PR TITLE
Add missing space after `implements` keyword

### DIFF
--- a/reference/_components/DocBlockSubtitleClass.tsx
+++ b/reference/_components/DocBlockSubtitleClass.tsx
@@ -7,12 +7,12 @@ export default function (
     <>
       {subtitle.implements && (
         <div>
-          <span className="type">implements</span>
+          <span className="type">implements</span>{" "}
           {subtitle.implements.map((impl, i) => (
             <>
               {/*typedef rendering*/}
               <span dangerouslySetInnerHTML={{ __html: impl }} />
-              {i !== (subtitle.implements.length - 1) && <span>,</span>}
+              {i !== (subtitle.implements.length - 1) && <span>,{" "}</span>}
             </>
           ))}
         </div>


### PR DESCRIPTION
Minor style fix similar to #1370 

Fixes missing space after `implements` as seen on:

- https://docs.deno.com/api/node/fs/~/Dir