### PR TITLE
docs: fix typo and update file-server examples to use latest version

### DIFF
--- a/deploy/manual/deployctl.md
+++ b/deploy/manual/deployctl.md
@@ -99,7 +99,7 @@ deploy an static site using `std/http/file_server.ts` (more details in
 [Static Site Tutorial](https://docs.deno.com/deploy/tutorials/static-site)):
 
 ```shell
-deployctl deploy --include=dist --entrypoint=jsr:@std/http/file_server
+deployctl deploy --include=dist --entrypoint=jsr:@std/http/file-server
 ```
 
 ### Environment variables

--- a/deploy/tutorials/static-site.md
+++ b/deploy/tutorials/static-site.md
@@ -39,7 +39,7 @@ You have now a html page that says "Hello" and has a logo.
 To deploy this repo on Deno Deploy, from the `static-site` repository, run:
 
 ```console
-deployctl deploy --project=<your-preferred-project-name> https://jsr.io/@std/http/1.0.7/file_server.ts
+deployctl deploy --project=<your-preferred-project-name> --entrypoint=jsr:@std/http/file-server
 ```
 
 To give a little more explanation of these commands: Because this is a static

--- a/deploy/tutorials/vite.md
+++ b/deploy/tutorials/vite.md
@@ -43,11 +43,11 @@ Now that we have everything in place, let's deploy your new project!
 7. Set the **Root directory** to `dist`
 8. Click **Deploy Project**
 
-> NB. The entrypoint that is set will be `jsr:@std/http/file-server`.
-> Note that this is not a file that exists in the Vite repo itself. Instead, it
-> is an external program. When run, this program uploads all the static asset
-> files in your current repo (`vite-project/dist`) to Deno Deploy. Then when you
-> navigate to the deployment URL, it serves up the local directory.
+> NB. The entrypoint that is set will be `jsr:@std/http/file-server`. Note that
+> this is not a file that exists in the Vite repo itself. Instead, it is an
+> external program. When run, this program uploads all the static asset files in
+> your current repo (`vite-project/dist`) to Deno Deploy. Then when you navigate
+> to the deployment URL, it serves up the local directory.
 
 ### `deployctl`
 

--- a/deploy/tutorials/vite.md
+++ b/deploy/tutorials/vite.md
@@ -43,7 +43,7 @@ Now that we have everything in place, let's deploy your new project!
 7. Set the **Root directory** to `dist`
 8. Click **Deploy Project**
 
-> NB. The entrypoint that is set will be `jsr:@std/http@1.0.0-rc.5/file-server`.
+> NB. The entrypoint that is set will be `jsr:@std/http/file-server`.
 > Note that this is not a file that exists in the Vite repo itself. Instead, it
 > is an external program. When run, this program uploads all the static asset
 > files in your current repo (`vite-project/dist`) to Deno Deploy. Then when you
@@ -56,5 +56,5 @@ Deploy.
 
 ```console
 cd /dist
-deployctl deploy --project=<project-name> jsr:@std/http@1.0.0-rc.5/file-server
+deployctl deploy --project=<project-name> --entrypoint=jsr:@std/http/file-server
 ```

--- a/examples/tutorials/file_server.md
+++ b/examples/tutorials/file_server.md
@@ -84,9 +84,9 @@ To use it, first install the remote script to your local file system:
 
 ```shell
 # Deno 1.x
-deno install --allow-net --allow-read jsr:@std/http@1/file-server
+deno install --allow-net --allow-read jsr:@std/http/file-server
 # Deno 2.x
-deno install --global --allow-net --allow-read jsr:@std/http@1/file-server
+deno install --global --allow-net --allow-read jsr:@std/http/file-server
 ```
 
 > This will install the script to the Deno installation root, e.g.

--- a/runtime/fundamentals/debugging.md
+++ b/runtime/fundamentals/debugging.md
@@ -72,7 +72,7 @@ server.
 Use the `--inspect-brk` flag to break execution on the first line:
 
 ```sh
-$ deno run --inspect-brk -RN jsr:@std/http@1.0.0/file-server
+$ deno run --inspect-brk -RN jsr:@std/http/file-server
 Debugger listening on ws://127.0.0.1:9229/ws/1e82c406-85a9-44ab-86b6-7341583480b1
 ...
 ```

--- a/runtime/reference/cli/compile.md
+++ b/runtime/reference/cli/compile.md
@@ -14,14 +14,14 @@ used to execute the script must be specified at compilation time. This includes
 permission flags.
 
 ```sh
-deno compile --allow-read --allow-net jsr:@std/http@1.0.0/file-server
+deno compile --allow-read --allow-net jsr:@std/http/file-server
 ```
 
 [Script arguments](/runtime/getting_started/command_line_interface/#passing-script-arguments)
 can be partially embedded.
 
 ```console
-deno compile --allow-read --allow-net jsr:@std/http@1.0.0/file-server -p 8080
+deno compile --allow-read --allow-net jsr:@std/http/file-server -p 8080
 
 ./file_server --help
 ```


### PR DESCRIPTION
- fix typo
- use latest file-server across all examples