### PR TITLE
fix: dark mode lint rule border

### DIFF
--- a/lint/index.tsx
+++ b/lint/index.tsx
@@ -78,7 +78,7 @@ export default function LintRulesIndex(
       <ul class="flex flex-col gap-4 !list-none !pl-0">
         {data.lintRulePages.map((lintRule, idx: number) => (
           <li
-            class="border-t md:border md:rounded-md pt-8 pb-4 md:p-4 lint-rule-box"
+            class="border-t md:border md:rounded-md pt-8 pb-4 md:p-4 lint-rule-box dark:border-gray-700"
             id={lintRule.label}
           >
             <div class="flex flex-row justify-start items-center gap-4 mb-2">


### PR DESCRIPTION
Before:

<img width="956" alt="Screenshot 2025-02-05 at 21 41 21" src="https://github.com/user-attachments/assets/5ec4336f-ec88-4ebb-b778-5bc1e93da25e" />

After:

<img width="950" alt="Screenshot 2025-02-05 at 21 41 26" src="https://github.com/user-attachments/assets/1577b123-67b3-4fd1-a80b-9b2c3aef4e73" />
