### PR TITLE
docs(linting_and_formatting): remove stabilized flags

### DIFF
--- a/runtime/fundamentals/linting_and_formatting.md
+++ b/runtime/fundamentals/linting_and_formatting.md
@@ -111,9 +111,6 @@ before being merged.
 | prose-wrap         | Define how prose should be wrapped                     | **always** | always, never, preserve |
 | single-quote       | Use single quotes                                      | **false**  | true, false             |
 | unstable-component | Enable formatting Svelte, Vue, Astro and Angular files |            |                         |
-| unstable-css       | Enable formatting CSS, SCSS, Sass and Less files       |            |                         |
-| unstable-html      | Enable formatting HTML files                           |            |                         |
-| unstable-yaml      | Enable formatting YAML files                           |            |                         |
 | unstable-sql       | Enable formatting SQL files                            |            |                         |
 | use-tabs           | Use tabs instead of spaces for indentation             | **false**  | true, false             |
 


### PR DESCRIPTION
no need to confuse beginners with needless flags considering they're stabilized in Deno 2.0
- https://github.com/denoland/deno/pull/25753
- https://deno.com/blog/v2.0