### PR TITLE
Fix vue code fences

### DIFF
--- a/examples/tutorials/vue.md
+++ b/examples/tutorials/vue.md
@@ -233,23 +233,25 @@ up earlier and render them as links using the
 
 ```html title="Dinosaurs.vue"
 <script lang="ts">
-import { defineComponent } from 'vue';
+  import { defineComponent } from "vue";
 
-export default defineComponent({
+  export default defineComponent({
     async setup() {
-        const res = await fetch("http://localhost:8000/dinosaurs")
-        const dinosaurs = await res.json() as Dinosaur[];
-        return { dinosaurs };
-    }
-});
+      const res = await fetch("http://localhost:8000/dinosaurs");
+      const dinosaurs = await res.json() as Dinosaur[];
+      return { dinosaurs };
+    },
+  });
 </script>
 
 <template>
-    <div v-for="dinosaur in dinosaurs" :key="dinosaur.name">
-        <RouterLink :to="{ name: 'Dinosaur', params: { dinosaur: `${dinosaur.name.toLowerCase()}` } }" >
-            {{ dinosaur.name }}
-        </RouterLink>
-    </div>
+  <div v-for="dinosaur in dinosaurs" :key="dinosaur.name">
+    <RouterLink
+      :to="{ name: 'Dinosaur', params: { dinosaur: `${dinosaur.name.toLowerCase()}` } }"
+    >
+      {{ dinosaur.name }}
+    </RouterLink>
+  </div>
 </template>
 ```
 
@@ -267,7 +269,7 @@ component. Add the following code to the `HomePage.vue` file:
 
 ```html title="HomePage.vue"
 <script setup lang="ts">
-import Dinosaurs from './Dinosaurs.vue';
+  import Dinosaurs from "./Dinosaurs.vue";
 </script>
 <template>
   <h1>Welcome to the Dinosaur App! 🦕</h1>
@@ -310,26 +312,28 @@ Then update the `Dinosaur.vue` file:
 
 ```html title="Dinosaur.vue"
 <script lang="ts">
-import { defineComponent } from 'vue';
+  import { defineComponent } from "vue";
 
-export default defineComponent({
+  export default defineComponent({
     props: { dinosaur: String },
     data(): ComponentData {
-        return { 
-            dinosaurDetails: null 
-        };
+      return {
+        dinosaurDetails: null,
+      };
     },
     async mounted() {
-        const res = await fetch(`http://localhost:8000/dinosaurs/${this.dinosaur}`);
-        this.dinosaurDetails = await res.json();
-    }
-});
+      const res = await fetch(
+        `http://localhost:8000/dinosaurs/${this.dinosaur}`,
+      );
+      this.dinosaurDetails = await res.json();
+    },
+  });
 </script>
 
 <template>
-    <h1>{{ dinosaurDetails?.name }}</h1>
-    <p>{{ dinosaurDetails?.description }}</p>
-    <RouterLink to="/">🠠 Back to all dinosaurs</RouterLink>
+  <h1>{{ dinosaurDetails?.name }}</h1>
+  <p>{{ dinosaurDetails?.description }}</p>
+  <RouterLink to="/">🠠 Back to all dinosaurs</RouterLink>
 </template>
 ```
 

--- a/examples/tutorials/vue.md
+++ b/examples/tutorials/vue.md
@@ -206,7 +206,7 @@ it to include only the `<RouterView>` component:
 ```html title="App.vue"
 <template>
   <RouterView />
-</template>;
+</template>
 ```
 
 ### The components

--- a/examples/tutorials/vue.md
+++ b/examples/tutorials/vue.md
@@ -203,7 +203,7 @@ at `/:dinosaur`.
 Finally, you can delete all of the code in the `src/App.vue` file to and update
 it to include only the `<RouterView>` component:
 
-```vue title="App.vue"
+```html title="App.vue"
 <template>
   <RouterView />
 </template>;
@@ -231,7 +231,7 @@ up earlier and render them as links using the
 `lang="ts"` attribute on the script tag.) Add the following code to the
 `Dinosaurs.vue` file:
 
-```vue title="Dinosaurs.vue"
+```html title="Dinosaurs.vue"
 <script lang="ts">
 import { defineComponent } from 'vue';
 
@@ -265,7 +265,7 @@ uniquely identify each dinosaur.
 The homepage will contain a heading and then it will render the `Dinosaurs`
 component. Add the following code to the `HomePage.vue` file:
 
-```vue title="HomePage.vue"
+```html title="HomePage.vue"
 <script setup lang="ts">
 import Dinosaurs from './Dinosaurs.vue';
 </script>
@@ -308,7 +308,7 @@ type ComponentData = {
 
 Then update the `Dinosaur.vue` file:
 
-```vue title="Dinosaur.vue"
+```html title="Dinosaur.vue"
 <script lang="ts">
 import { defineComponent } from 'vue';
 


### PR DESCRIPTION
Our markdown parser and syntax highlighter doesn't know how to handle `vue` as a content type.
We can just use `html` here.

fixes: #1386 
