### PR TITLE
Add links between lint pages

### DIFF
--- a/lint/index.tsx
+++ b/lint/index.tsx
@@ -39,7 +39,13 @@ export default function LintRulesIndex(
   return (
     <div>
       <div class="flex flex-col gap-4 mb-8">
-        <p>These lint rules are provided by the <a href="/runtime/reference/cli/lint/"><code>deno lint</code></a> command.</p>
+        <p>
+          These lint rules are provided by the{" "}
+          <a href="/runtime/reference/cli/lint/">
+            <code>deno lint</code>
+          </a>{" "}
+          command.
+        </p>
         <input
           type="text"
           id="lint-rule-search"

--- a/lint/index.tsx
+++ b/lint/index.tsx
@@ -39,6 +39,7 @@ export default function LintRulesIndex(
   return (
     <div>
       <div class="flex flex-col gap-4 mb-8">
+        <p>These lint rules are provided by the <a href="/runtime/reference/cli/lint/"><code>deno lint</code></a> command.</p>
         <input
           type="text"
           id="lint-rule-search"

--- a/runtime/fundamentals/linting_and_formatting.md
+++ b/runtime/fundamentals/linting_and_formatting.md
@@ -43,8 +43,10 @@ The linter can be configured in a
 [`deno.json`](/runtime/fundamentals/configuration/) file. You can specify custom
 rules, plugins, and settings to tailor the linting process to your needs.
 
+### Linting rules
+
 You can view and search the list of available rules and their usage on
-[List of rules](/lint/) documentation page.
+the [List of rules](/lint/) documentation page.
 
 ## Formatting
 

--- a/runtime/fundamentals/linting_and_formatting.md
+++ b/runtime/fundamentals/linting_and_formatting.md
@@ -45,8 +45,8 @@ rules, plugins, and settings to tailor the linting process to your needs.
 
 ### Linting rules
 
-You can view and search the list of available rules and their usage on
-the [List of rules](/lint/) documentation page.
+You can view and search the list of available rules and their usage on the
+[List of rules](/lint/) documentation page.
 
 ## Formatting
 

--- a/runtime/reference/cli/lint.md
+++ b/runtime/reference/cli/lint.md
@@ -10,8 +10,8 @@ command: lint
 
 ## Available rules
 
-For a complete list of supported rules, visit
-[List of rules](/lint/) documentation page.
+For a complete list of supported rules, visit [List of rules](/lint/)
+documentation page.
 
 ## Ignore directives
 

--- a/runtime/reference/cli/lint.md
+++ b/runtime/reference/cli/lint.md
@@ -11,7 +11,7 @@ command: lint
 ## Available rules
 
 For a complete list of supported rules, visit
-[List of rules](https://docs.deno.com/lint/) documentation page.
+[List of rules](/lint/) documentation page.
 
 ## Ignore directives
 


### PR DESCRIPTION
- Adds a link from list of rules at `/lint` to the CLI reference page on `deno lint` at `/runtime/reference/cli/lint/`
- Makes existing link on `/runtime/fundamentals/linting_and_formatting/` page to the List of Rules pag more prominent
- Makes existing link on CLI reference page at `/runtime/reference/cli/lint/` to the List of Rules root relative