### PR TITLE
fix: add missing docs for jsx rules

### DIFF
--- a/lint/rules/jsx-button-has-type.md
+++ b/lint/rules/jsx-button-has-type.md
@@ -1,0 +1,21 @@
+---
+tags: [recommended, react, jsx, fresh]
+---
+
+Enforce `<button>` elements to have a `type` attribute. If a `<button>` is placed inside a `<form>` element it will act as a submit button by default which can be unexpected.
+
+**Invalid:**
+
+```tsx
+const btn = <button>click me</button>;
+const btn = <button type="2">click me</button>;
+```
+
+**Valid:**
+
+```tsx
+const btn = <button type="button">click me</button>;
+const btn = <button type="submit">click me</button>;
+const btn = <button type={btnType}>click me</button>;
+const btn = <button type={condition ? "button" : "submit"}>click me</button>;
+```

--- a/lint/rules/jsx-button-has-type.md
+++ b/lint/rules/jsx-button-has-type.md
@@ -2,7 +2,9 @@
 tags: [recommended, react, jsx, fresh]
 ---
 
-Enforce `<button>` elements to have a `type` attribute. If a `<button>` is placed inside a `<form>` element it will act as a submit button by default which can be unexpected.
+Enforce `<button>` elements to have a `type` attribute. If a `<button>` is
+placed inside a `<form>` element it will act as a submit button by default which
+can be unexpected.
 
 **Invalid:**
 

--- a/lint/rules/jsx-curly-braces.md
+++ b/lint/rules/jsx-curly-braces.md
@@ -1,5 +1,5 @@
 ---
-tags: []
+tags: [recommended, react, jsx]
 ---
 
 Ensure consistent use of curly braces around JSX expressions.

--- a/lint/rules/jsx-key.md
+++ b/lint/rules/jsx-key.md
@@ -1,5 +1,5 @@
 ---
-tags: []
+tags: [recommended, react, jsx]
 ---
 
 Ensure the `key` attribute is present when passing iterables into JSX. It allows

--- a/lint/rules/jsx-no-children-prop.md
+++ b/lint/rules/jsx-no-children-prop.md
@@ -1,5 +1,5 @@
 ---
-tags: []
+tags: [recommended, react, jsx, fresh]
 ---
 
 Pass children as JSX children instead of as an attribute.

--- a/lint/rules/jsx-no-comment-text-nodes.md
+++ b/lint/rules/jsx-no-comment-text-nodes.md
@@ -2,7 +2,8 @@
 tags: [recommended, react, jsx, fresh]
 ---
 
-JavaScript comments inside text nodes are rendered as plain text in JSX. This is often unexpected.
+JavaScript comments inside text nodes are rendered as plain text in JSX. This is
+often unexpected.
 
 **Invalid:**
 
@@ -14,5 +15,5 @@ JavaScript comments inside text nodes are rendered as plain text in JSX. This is
 **Valid:**
 
 ```tsx
-<div>{/* comment */}</div>
+<div>{/* comment */}</div>;
 ```

--- a/lint/rules/jsx-no-comment-text-nodes.md
+++ b/lint/rules/jsx-no-comment-text-nodes.md
@@ -1,0 +1,18 @@
+---
+tags: [recommended, react, jsx, fresh]
+---
+
+JavaScript comments inside text nodes are rendered as plain text in JSX. This is often unexpected.
+
+**Invalid:**
+
+```tsx
+<div>// comment</div>
+<div>/* comment */</div>
+```
+
+**Valid:**
+
+```tsx
+<div>{/* comment */}</div>
+```

--- a/lint/rules/jsx-no-duplicate-props.md
+++ b/lint/rules/jsx-no-duplicate-props.md
@@ -1,5 +1,5 @@
 ---
-tags: []
+tags: [recommended, react, jsx, fresh]
 ---
 
 Disallow duplicated JSX props. Later props will always overwrite earlier props

--- a/lint/rules/jsx-no-unescaped-entities.md
+++ b/lint/rules/jsx-no-unescaped-entities.md
@@ -2,7 +2,8 @@
 tags: [recommended, react, jsx, fresh]
 ---
 
-Leaving the `>` or `}` character in JSX is often undesired and difficult to spot. Enforce that these characters must be passed as strings.
+Leaving the `>` or `}` character in JSX is often undesired and difficult to
+spot. Enforce that these characters must be passed as strings.
 
 **Invalid:**
 

--- a/lint/rules/jsx-no-unescaped-entities.md
+++ b/lint/rules/jsx-no-unescaped-entities.md
@@ -1,0 +1,20 @@
+---
+tags: [recommended, react, jsx, fresh]
+---
+
+Leaving the `>` or `}` character in JSX is often undesired and difficult to spot. Enforce that these characters must be passed as strings.
+
+**Invalid:**
+
+```tsx
+<div>></div>
+<div>}</div>
+```
+
+**Valid:**
+
+```tsx
+<div>&gt;</div>,
+<div>{">"}</div>,
+<div>{"}"}</div>,
+```

--- a/lint/rules/jsx-no-useless-fragment.md
+++ b/lint/rules/jsx-no-useless-fragment.md
@@ -1,5 +1,5 @@
 ---
-tags: []
+tags: [recommended, react, jsx, fresh]
 ---
 
 Fragments are only necessary at the top of a JSX "block" and only when there are

--- a/lint/rules/jsx-props-no-spread-multi.md
+++ b/lint/rules/jsx-props-no-spread-multi.md
@@ -1,5 +1,5 @@
 ---
-tags: []
+tags: [recommended, react, jsx]
 ---
 
 Spreading the same expression twice is typically a mistake and causes

--- a/lint/rules/jsx-void-dom-elements-no-children.md
+++ b/lint/rules/jsx-void-dom-elements-no-children.md
@@ -1,5 +1,5 @@
 ---
-tags: []
+tags: [recommended, react, jsx, fresh]
 ---
 
 Ensure that void elements in HTML don't have any children as that is not valid

--- a/lint/rules/react-no-danger-with-children.md
+++ b/lint/rules/react-no-danger-with-children.md
@@ -1,5 +1,5 @@
 ---
-tags: []
+tags: [react, fresh]
 ---
 
 Using JSX children together with `dangerouslySetInnerHTML` is invalid as they
@@ -10,11 +10,11 @@ will be ignored.
 ```tsx
 <div dangerouslySetInnerHTML={{ __html: "<h1>hello</h1>" }}>
   <h1>this will never be rendered</h1>
-</div>;
+</div>
 ```
 
 **Valid:**
 
 ```tsx
-<div dangerouslySetInnerHTML={{ __html: "<h1>hello</h1>" }} />;
+<div dangerouslySetInnerHTML={{ __html: "<h1>hello</h1>" }} />
 ```

--- a/lint/rules/react-no-danger-with-children.md
+++ b/lint/rules/react-no-danger-with-children.md
@@ -10,11 +10,11 @@ will be ignored.
 ```tsx
 <div dangerouslySetInnerHTML={{ __html: "<h1>hello</h1>" }}>
   <h1>this will never be rendered</h1>
-</div>
+</div>;
 ```
 
 **Valid:**
 
 ```tsx
-<div dangerouslySetInnerHTML={{ __html: "<h1>hello</h1>" }} />
+<div dangerouslySetInnerHTML={{ __html: "<h1>hello</h1>" }} />;
 ```

--- a/lint/rules/react-no-danger.md
+++ b/lint/rules/react-no-danger.md
@@ -1,5 +1,5 @@
 ---
-tags: []
+tags: [react, fresh]
 ---
 
 Prevent the use of `dangerouslySetInnerHTML` which can lead to XSS

--- a/lint/rules/react-rules-of-hooks.md
+++ b/lint/rules/react-rules-of-hooks.md
@@ -1,0 +1,47 @@
+---
+tags: [react, fresh]
+---
+
+Ensure that hooks are called correctly in React/Preact components. They must be called at the top level of a component and not inside a conditional statement or a loop.
+
+**Invalid:**
+
+```tsx
+// WRONG: Called inside condition
+function MyComponent() {
+  if (condition) {
+    const [count, setCount] = useState(0);
+  }
+}
+
+// WRONG: Called inside for loop
+function MyComponent() {
+  for (const item of items) {
+    const [count, setCount] = useState(0);
+  }
+}
+
+// WRONG: Called inside while loop
+function MyComponent() {
+  while (condition) {
+    const [count, setCount] = useState(0);
+  }
+}
+
+// WRONG: Called after condition
+function MyComponent() {
+  if (condition) {
+    // ...
+  }
+
+  const [count, setCount] = useState(0);
+}
+```
+
+**Valid:**
+
+```tsx
+function MyComponent() {
+  const [count, setCount] = useState(0);
+}
+```

--- a/lint/rules/react-rules-of-hooks.md
+++ b/lint/rules/react-rules-of-hooks.md
@@ -2,7 +2,9 @@
 tags: [react, fresh]
 ---
 
-Ensure that hooks are called correctly in React/Preact components. They must be called at the top level of a component and not inside a conditional statement or a loop.
+Ensure that hooks are called correctly in React/Preact components. They must be
+called at the top level of a component and not inside a conditional statement or
+a loop.
 
 **Invalid:**
 


### PR DESCRIPTION
- Add missing docs for new JSX rules
- Rename `no-danger` -> `react-no-danger`
- Rename `jsx-no-danger-with-children` -> `react-no-danger-with-children`
- Add missing tags to jsx rules