### PR TITLE
Update style for text only snippets

### DIFF
--- a/examples/_components/ExamplePage.tsx
+++ b/examples/_components/ExamplePage.tsx
@@ -45,8 +45,9 @@ export default function ExamplePage({ example }: Props) {
             <SnippetComponent
               key={i}
               onlyOneSnippet={file.snippets.length === 1}
-              firstOfFile={i === 0}
-              lastOfFile={i === file.snippets.length - 1}
+              firstOfFile={i === 0 || !file.snippets[i - 1].code}
+              lastOfFile={i === file.snippets.length - 1 ||
+                !file.snippets[i + 1].code}
               filename={file.name}
               snippet={snippet}
             />

--- a/examples/_components/SnippetComponent.tsx
+++ b/examples/_components/SnippetComponent.tsx
@@ -14,7 +14,7 @@ export default function SnippetComponent(props: {
     <div class="grid grid-cols-1 sm:grid-cols-10 gap-x-8">
       <div
         class={`italic select-none text-sm text-balance ${
-          props.snippet.text ? "pb-4 mt-4 md:pb-0 " : " "
+          props.snippet.text ? "pb-4 mt-4 " : " "
         } ${
           props.snippet.code ? "col-span-5 sm:col-span-3" : "mt-4 col-span-full"
         }`}

--- a/examples/_components/SnippetComponent.tsx
+++ b/examples/_components/SnippetComponent.tsx
@@ -13,10 +13,12 @@ export default function SnippetComponent(props: {
   return (
     <div class="grid grid-cols-1 sm:grid-cols-10 gap-x-8">
       <div
-        class={`italic select-none text-sm text-balance ${
+        class={`select-none text-sm ${
           props.snippet.text ? "pb-4 mt-4 " : " "
         } ${
-          props.snippet.code ? "col-span-5 sm:col-span-3" : "mt-4 col-span-full"
+          props.snippet.code
+            ? "italic text-balance col-span-5 sm:col-span-3"
+            : "mt-4 col-span-full"
         }`}
       >
         {props.snippet.text}

--- a/examples/_components/SnippetComponent.tsx
+++ b/examples/_components/SnippetComponent.tsx
@@ -17,7 +17,7 @@ export default function SnippetComponent(props: {
           props.snippet.text ? "pb-4 mt-4 " : " "
         } ${
           props.snippet.code
-            ? "italic text-balance col-span-5 sm:col-span-3"
+            ? "italic text-balance col-span-5 sm:col-span-3 md:pb-0"
             : "mt-4 col-span-full"
         }`}
       >


### PR DESCRIPTION
Trying to improve how some examples with text only snippets are displayed.


| Page | Before  | After |
| ------ | ------------- | ------------- |
| [Hashing](https://docs.deno.com/examples/hashing/)  | ![image](https://github.com/user-attachments/assets/785de5ef-c3e6-4221-b2d4-1bb6c9390368)  | ![image](https://github.com/user-attachments/assets/5cfe7571-225d-44d5-83c5-4b19c7dd637a)  |
| [Create & Remove Dirs](https://docs.deno.com/examples/create_remove_directories/) | ![image](https://github.com/user-attachments/assets/0d444701-305a-4560-b569-c20cda771682) | ![image](https://github.com/user-attachments/assets/2d3855a3-e69b-4115-a748-faeee2cc64e2) |
| [Piping streams](https://docs.deno.com/examples/piping_streams) | ![image](https://github.com/user-attachments/assets/d0e2ba95-fe40-4ee6-9117-e497febd8c05) | ![image](https://github.com/user-attachments/assets/612094ef-6012-4c2f-8913-e8742a8054dd) |

All the pages that had text-only snippets:

Deployed:
https://docs.deno.com/examples/hashing
https://docs.deno.com/examples/create_remove_directories
https://docs.deno.com/examples/piping_streams
https://docs.deno.com/examples/moving_renaming_files
https://docs.deno.com/examples/environment_variables
https://docs.deno.com/examples/writing_files
https://docs.deno.com/examples/hono
https://docs.deno.com/examples/color_logging
https://docs.deno.com/examples/reading_files

PR Preview:
https://deno-docs-m60zscf6z8fj.deno.dev/examples/hashing
https://deno-docs-m60zscf6z8fj.deno.dev/examples/create_remove_directories
https://deno-docs-m60zscf6z8fj.deno.dev/examples/piping_streams
https://deno-docs-m60zscf6z8fj.deno.dev/examples/moving_renaming_files
https://deno-docs-m60zscf6z8fj.deno.dev/examples/environment_variables
https://deno-docs-m60zscf6z8fj.deno.dev/examples/writing_files
https://deno-docs-m60zscf6z8fj.deno.dev/examples/hono
https://deno-docs-m60zscf6z8fj.deno.dev/examples/color_logging
https://deno-docs-m60zscf6z8fj.deno.dev/examples/reading_files


Screenshots are using Firefox.