### PR TITLE
Swap order of client and server in async example

### DIFF
--- a/runtime/reference/cli/task.md
+++ b/runtime/reference/cli/task.md
@@ -325,21 +325,21 @@ deno run output_data.ts ; deno run --allow-net server.ts
 Async commands provide a way to make a command execute asynchronously. This can
 be useful when starting multiple processes. To make a command asynchronous, add
 an `&` to the end of it. For example the following would execute
-`sleep 1 && deno run --allow-net client.ts` and `deno run --allow-net server.ts`
+`sleep 1 && deno run --allow-net server.ts` and `deno run --allow-net client.ts`
 at the same time:
 
 ```sh
-sleep 1 && deno run --allow-net client.ts & deno run --allow-net server.ts
+sleep 1 && deno run --allow-net server.ts & deno run --allow-net client.ts
 ```
 
 Unlike in most shells, the first async command to fail will cause all the other
 commands to fail immediately. In the example above, this would mean that if the
-client command fails then the server command will also fail and exit. You can
+server command fails then the cleint command will also fail and exit. You can
 opt out of this behavior by adding `|| true` to the end of a command, which will
 force a `0` exit code. For example:
 
 ```sh
-deno run --allow-net client.ts || true & deno run --allow-net server.ts || true
+deno run --allow-net server.ts || true & deno run --allow-net client.ts || true
 ```
 
 ### Environment variables


### PR DESCRIPTION
Switch order of client and server tasks in async example to conform to the mental model a little more naturally.