### PR TITLE
misc style updates

### DIFF
--- a/_components/Footer.css
+++ b/_components/Footer.css
@@ -11,10 +11,6 @@ footer {
   gap: 2rem;
 }
 
-.footer-section {
-  min-width: 200px;
-}
-
 .footer-section-heading {
   margin-bottom: 1rem;
   font-size: 1rem;

--- a/_components/Navigation.tsx
+++ b/_components/Navigation.tsx
@@ -32,13 +32,13 @@ function getSectionData(data: Lume.Data, currentUrl: string) {
     const childItems = categoryPanel.categories;
 
     childItems.push({
-      title: `View all ${categoryPanel.total_symbols} symbols`,
+      name: `View all ${categoryPanel.total_symbols} symbols`,
       href: categoryPanel.all_symbols_href,
       active: currentUrl.includes("all_symbols"),
     });
 
     const sectionData = [{
-      title: "Categories",
+      name: "Categories",
       href: "/reference",
       items: childItems,
     }];

--- a/reference/_components/Example.tsx
+++ b/reference/_components/Example.tsx
@@ -8,10 +8,6 @@ export default function (
       <comp.anchor anchor={example.anchor} />
 
       {/*markdown rendering; usually not markdown but just a string, but some cases might be markdown (ie the title contains inline-code)*/}
-      <h3
-        class="example-header"
-        dangerouslySetInnerHTML={{ __html: example.markdown_title }}
-      />
 
       {/*markdown rendering*/}
       <div dangerouslySetInnerHTML={{ __html: example.markdown_body }} />

--- a/static/reference_styles.css
+++ b/static/reference_styles.css
@@ -746,12 +746,6 @@ ul.namespaceItemContentSubItems {
 .ddoc .docNodeKindIcon > * + * {
   margin-left: -0.375rem;
 }
-.ddoc .example-header {
-  margin-bottom: 0.75rem;
-  font-size: 1.125rem;
-  font-weight: 700;
-  line-height: 1.75rem;
-}
 .ddoc .toc h3 {
   margin-bottom: 0.75rem;
   font-size: 1.125rem;


### PR DESCRIPTION
fix footer spacing

add 'see all symbols' link back to righthand nav on reference pages

remove doubled up 'Examples header' as per https://github.com/denoland/docs/issues/1330