### PR TITLE
Fix overflowing content

### DIFF
--- a/_components/Navigation.css
+++ b/_components/Navigation.css
@@ -1,6 +1,5 @@
 .nav {
   height: 100%;
-  min-width: 16rem;
   border-right: 1px solid hsl(var(--foreground-tertiary));
   font-size: 0.8rem;
   background-color: hsl(var(--background-primary));

--- a/_components/Navigation.css
+++ b/_components/Navigation.css
@@ -1,6 +1,6 @@
 .nav {
   height: 100%;
-  min-width: 280px;
+  min-width: 16rem;
   border-right: 1px solid hsl(var(--foreground-tertiary));
   font-size: 0.8rem;
   background-color: hsl(var(--background-primary));

--- a/_components/TableOfContents.css
+++ b/_components/TableOfContents.css
@@ -9,7 +9,7 @@
 @media (min-width: 1024px) {
   .content {
     display: grid;
-    grid-template-columns: minmax(auto, 960px) 1fr;
+    grid-template-columns: minmax(0, 8fr) minmax(0, 3fr);
   }
 
   .toc-desktop {
@@ -19,7 +19,6 @@
     top: 4rem;
     max-height: calc(100vh - 4rem);
     height: max-content;
-    min-width: 250px;
     overflow-y: auto;
     border-left: 1px solid hsl(var(--foreground-tertiary));
   }
@@ -48,6 +47,12 @@
     height: 1.3em;
     background-color: hsl(var(--background-secondary));
     clip-path: polygon(0% 10%, 100% 50%, 0% 90%);
+  }
+}
+
+@media (min-width: 86rem) {
+  .content {
+    grid-template-columns: minmax(0, 1fr) minmax(20rem, max-content);
   }
 }
 

--- a/_includes/doc.tsx
+++ b/_includes/doc.tsx
@@ -20,7 +20,7 @@ export default function Doc(data: Lume.Data, helpers: Lume.Helpers) {
 
   return (
     <div id="content" className="content">
-      <div class="px-4 sm:px-5 md:px-6 max-w-full">
+      <div class="px-4 sm:px-5 md:px-6 w-full max-w-[60rem] mx-auto">
         <article class="mx-auto">
           {(!isExamples && !isHome && !isReference) && (
             <data.comp.Breadcrumbs

--- a/static/style.css
+++ b/static/style.css
@@ -34,6 +34,7 @@ p {
       "nav main"
       "nav footer";
     grid-template-columns: auto 1fr;
+    width: 100%;
   }
 
   .nav {


### PR DESCRIPTION
Fixes the horizontal overflow issue on some pages by explicitly setting column minimum widths to 0, and by removing minimum width from the sidebars. This gives the grid full control over the column widths, and doesn't allow any grid items to force the columns to be wider.

![CleanShot 2025-02-20 at 13 52 47@2x](https://github.com/user-attachments/assets/1a9e60f1-b10f-4e72-b3f1-6255cf5249d4)
