### PR TITLE
docs: add selector tips to lint plugins

### DIFF
--- a/runtime/reference/lint_plugins.md
+++ b/runtime/reference/lint_plugins.md
@@ -142,7 +142,7 @@ tree instead of when going down.
 We highly recommend using the
 [typescript-eslint playground](https://typescript-eslint.io/play/) when
 developing lint rules. It allows you to inspect code and the resulting AST
-format. This makes it easy to see which selectors match which node a lot easier.
+format. This makes it easier to see which selectors match which node.
 
 :::
 

--- a/runtime/reference/lint_plugins.md
+++ b/runtime/reference/lint_plugins.md
@@ -133,6 +133,19 @@ supported syntax for selectors is:
 | `:not(> Bar)`          | Not pseudo-class              |
 | `:is(> Bar)`           | Is pseudo-class               |
 
+There is also the `:exit` pseudo that is only valid at the end of the whole
+selector. When it's present, Deno will call the function while going **up** the
+tree instead of when going down.
+
+:::tip
+
+We highly recommend using the
+[typescript-eslint playground](https://typescript-eslint.io/play/) when
+developing lint rules. It allows you to inspect code and the resulting AST
+format. This makes it easy to see which selectors match which node a lot easier.
+
+:::
+
 ## Applying fixes
 
 A custom lint rule can supply a function to apply a fix when reporting a


### PR DESCRIPTION
- Point to `typescript-eslint`'s playground when developing plugins
- Add note about `:exit` pseudo