### PR TITLE
Update minor release schedule to reflect revised plans

### DIFF
--- a/runtime/fundamentals/stability_and_releases.md
+++ b/runtime/fundamentals/stability_and_releases.md
@@ -10,11 +10,11 @@ strive to make code working under 1.0.0 continue to work in future versions.
 
 ## Release schedule, channels and long term support
 
-Deno releases a new stable, minor version (eg. v2.1.0, v2.0.0) on a monthly
+Deno releases a new stable, minor version (eg. v2.1.0, v2.0.0) on a 12 week
 schedule.
 
 Patch releases including bug fixes for the latest minor version are released as
-needed - you can expect two or three patch releases before a new minor version
+needed - you can expect several patch releases before a new minor version
 is released.
 
 ### Release channels


### PR DESCRIPTION
In addition to this page, which was recently updated: https://docs.deno.com/runtime/contributing/release_schedule/ we also mention our release cadence here https://docs.deno.com/runtime/fundamentals/stability_and_releases/

This PR updates the language on this second page to reflect the 12 week minor release cycle