### PR TITLE
docs: add note for DENO_TRACE_PERMISSIONS

### DIFF
--- a/runtime/fundamentals/security.md
+++ b/runtime/fundamentals/security.md
@@ -90,6 +90,8 @@ deno run -A script.ts
 deno run --allow-all script.ts
 ```
 
+By default, Deno will not generate a stack trace for permission requests as it comes with a hit to performance. Users can enable stack traces with the `DENO_TRACE_PERMISSIONS` environment variable.
+
 ### File system access
 
 By default, executing code can not read or write arbitrary files on the file

--- a/runtime/fundamentals/security.md
+++ b/runtime/fundamentals/security.md
@@ -90,7 +90,9 @@ deno run -A script.ts
 deno run --allow-all script.ts
 ```
 
-By default, Deno will not generate a stack trace for permission requests as it comes with a hit to performance. Users can enable stack traces with the `DENO_TRACE_PERMISSIONS` environment variable.
+By default, Deno will not generate a stack trace for permission requests as it
+comes with a hit to performance. Users can enable stack traces with the
+`DENO_TRACE_PERMISSIONS` environment variable.
 
 ### File system access
 


### PR DESCRIPTION
feature was added in https://github.com/denoland/deno/pull/26938 but never documented. 