### PR TITLE
fix: raise nav sidebar z-index

### DIFF
--- a/_components/Navigation.css
+++ b/_components/Navigation.css
@@ -17,6 +17,7 @@
     transition: transform 200ms ease-in-out;
     transform: translateX(-100%);
     background-color: hsl(var(--background-primary));
+    z-index: 11;
   }
 
   .hamburger-label {


### PR DESCRIPTION
Prior to this commit, when the viewport is less than 1024px, the titles of some snippets would go on top of the sidebar. This raises the z-index of the nav sidebar so that it will always go over these texts.

### nav closed
![before](https://github.com/user-attachments/assets/c060a36e-7304-45a2-8230-bc6f6ec23653)

### nav opened
![after](https://github.com/user-attachments/assets/3b3efae0-1331-4651-b4ea-28e0d3b6b59e)
