### PR TITLE
fix: change websockets url

### DIFF
--- a/index.page.tsx
+++ b/index.page.tsx
@@ -250,7 +250,7 @@ export default function () {
                     },
                     {
                       text: "WebSockets",
-                      href: "/api/deno/web-sockets",
+                      href: "/api/deno/websockets",
                     },
                     {
                       text: "View all Deno APIs",


### PR DESCRIPTION
Prior to this commit, the link to the websockets API page was broken (404). It was supposed to be `https://docs.deno.com/api/deno/websockets` instead of `https://docs.deno.com/api/deno/web-sockets`.