### PR TITLE
Tanstack: Add brackets for origin field when setting CORS

### DIFF
--- a/examples/tutorials/tanstack.md
+++ b/examples/tutorials/tanstack.md
@@ -83,7 +83,7 @@ const app = new Hono();
 app.use(
   "/api/*",
   cors({
-    origin: "http://localhost:5173",
+    origin: ["http://localhost:5173"],
     allowMethods: ["GET", "POST", "PUT", "DELETE"],
     allowHeaders: ["Content-Type", "Authorization"],
     exposeHeaders: ["Content-Type", "Authorization"],


### PR DESCRIPTION
## What?

For the tanstack tutorial, add brackets for the origin field when setting cors in the Hono api.

## Why?

Otherwise, you get cors errors.
There's a [forum post](https://questions.deno.com/m/1311051310673690765) that encountered the issue, but setting the origin as an array fixes it.