### PR TITLE
docs(reference/lint_plugins): Clarify "Testing plugins" example

### DIFF
--- a/runtime/reference/lint_plugins.md
+++ b/runtime/reference/lint_plugins.md
@@ -52,7 +52,7 @@ All the typings are available under the `Deno.lint` namespace.
 :::
 
 ```ts title="my-plugin.ts"
-export default {
+const plugin: Deno.lint.Plugin = {
   // The name of your plugin. Will be shown in error output
   name: "my-plugin",
   // Object with rules. The property name is the rule name and
@@ -83,7 +83,8 @@ export default {
       },
     },
   },
-} satisfies Deno.lint.Plugin;
+};
+export default plugin;
 ```
 
 ## Using selectors to match nodes
@@ -94,7 +95,7 @@ express via a selector, similar to CSS selectors. By using a string as the
 property name in the returned visitor object, we can specify a custom selector.
 
 ```ts title="my-plugin.ts"
-export default {
+const plugin: Deno.lint.Plugin = {
   name: "my-plugin",
   rules: {
     "my-rule": {
@@ -112,7 +113,8 @@ export default {
       },
     },
   },
-} satisfies Deno.lint.Plugin;
+};
+export default plugin;
 ```
 
 Note, that we can always refine our match further in JavaScript if the matching
@@ -202,7 +204,7 @@ can hook into the linter via the `destroy()` hook. It is called after a file has
 been linted and just before the plugin context is destroyed.
 
 ```ts title="my-plugin.ts"
-export default {
+const plugin: Deno.lint.Plugin = {
   name: "my-plugin",
   rules: {
     "my-rule": {
@@ -216,7 +218,8 @@ export default {
       },
     },
   },
-} satisfies Deno.lint.Plugin;
+};
+export default plugin;
 ```
 
 :::caution

--- a/runtime/reference/lint_plugins.md
+++ b/runtime/reference/lint_plugins.md
@@ -257,8 +257,8 @@ particular input.
 
 Let's use the example plugin, defined above:
 
-```ts title="my-plugin-test.ts"
-import { assert, assertEquals } from "jsr:@std/assert";
+```ts title="my-plugin_test.ts"
+import { assertEquals } from "jsr:@std/assert";
 import myPlugin from "./my-plugin.ts";
 
 Deno.test("my-plugin", () => {
@@ -272,6 +272,7 @@ Deno.test("my-plugin", () => {
   const d = diagnostics[0];
   assertEquals(d.id, "my-plugin/my-rule");
   assertEquals(d.message, "should be _b");
+  assertEquals(d.fix, [{ range: [6, 8], text: "_b" }]);
 });
 ```
 

--- a/runtime/reference/lint_plugins.md
+++ b/runtime/reference/lint_plugins.md
@@ -260,7 +260,7 @@ import myPlugin from "./my-plugin.ts";
 
 Deno.test("my-plugin", () => {
   const diagnostics = Deno.lint.runPlugin(
-    plugin,
+    myPlugin,
     "main.ts", // Dummy filename, file doesn't need to exist.
     "const _a = 'a';",
   );

--- a/runtime/reference/lint_plugins.md
+++ b/runtime/reference/lint_plugins.md
@@ -259,13 +259,16 @@ import { assert, assertEquals } from "jsr:@std/assert";
 import myPlugin from "./my-plugin.ts";
 
 Deno.test("my-plugin", () => {
-  const diagnostics = Deno.lint.runPlugin(plugin, "main.ts", "const _a = 'a';");
+  const diagnostics = Deno.lint.runPlugin(
+    plugin,
+    "main.ts", // Dummy filename, file doesn't need to exist.
+    "const _a = 'a';",
+  );
 
   assertEquals(diagnostics.length, 1);
   const d = diagnostics[0];
   assertEquals(d.id, "my-plugin/my-rule");
   assertEquals(d.message, "should be _b");
-  assert(typeof d.fix === "function");
 });
 ```
 
@@ -280,4 +283,4 @@ Trying to use it with any other subcommand will throw an error.
 
 Consult [the API reference](/api/deno/) for more information on
 [`Deno.lint.runPlugin`](/api/deno/~/Deno.lint.runPlugin) and
-[`Deno.lint.Diagnostic`](/api/deno/~/Deno.lint.runPlugin).
+[`Deno.lint.Diagnostic`](/api/deno/~/Deno.lint.Diagnostic).


### PR DESCRIPTION
Hi there - I read this page while doing the [Lint Rules Contest](https://deno.com/blog/lint-rules-contest) today and based on that have made a few small changes to fix it / make it clearer:

1. Used normal type annotations for the example linter's default export, rather than `satisfies Deno.lint.Plugin` (This is because I noticed when publishing my own plugin that JSR complained about the latter being a "slow type").
2. Fixed the example test file name to use a `_` rather than `-`, so that `deno test` picks it up by default.
4. Mentioned that the filename we give to `Deno.lint.runPlugin` is just a dummy (we provide the source-code to lint as a string).
5. Fixed the assert for `Deno.lint.Diagnostic.fix` in the example test (it is never a function either way).
6. Fixed the link to the API documentation for `Deno.lint.Diagnostic`.

