### PR TITLE
fix: lint rule search not cleared on empty input

### DIFF
--- a/lint_rules.client.ts
+++ b/lint_rules.client.ts
@@ -1,21 +1,16 @@
 const searchbar = document.getElementById("lint-rule-search");
-function selectAllLintRuleBoxes() {
-  return document.querySelectorAll(".lint-rule-box");
-}
 
 if (searchbar) {
   searchbar.addEventListener("input", (e) => {
     const query = e.currentTarget?.value;
 
-    if (query) {
-      const allBoxes = selectAllLintRuleBoxes();
+    const allBoxes = document.querySelectorAll(".lint-rule-box");
 
-      for (const box of allBoxes) {
-        if (!box.id.includes(query)) {
-          box.style.display = "none";
-        } else {
-          box.style.display = "block";
-        }
+    for (const box of allBoxes) {
+      if (!box.id.includes(query)) {
+        box.style.display = "none";
+      } else {
+        box.style.display = "block";
       }
     }
   });


### PR DESCRIPTION
The search value wasn't reset internally when it had a value and was cleared again.

Fixes https://github.com/denoland/docs/issues/1513