### PR TITLE
fix: lint rule items jumping around on search

### DIFF
--- a/lint/index.tsx
+++ b/lint/index.tsx
@@ -85,7 +85,7 @@ export default function LintRulesIndex(
       <ul class="flex flex-col gap-4 !list-none !pl-0">
         {data.lintRulePages.map((lintRule, idx: number) => (
           <li
-            class="border-t md:border md:rounded-md pt-8 pb-4 md:p-4 lint-rule-box dark:border-gray-700"
+            class="border-t md:border md:rounded-md pt-8 pb-4 md:p-4 lint-rule-box dark:border-gray-700 !mt-0"
             id={lintRule.title}
           >
             <div class="flex flex-row justify-start items-center gap-4 mb-2">


### PR DESCRIPTION
The lint rule filtering page inherits styles from `gfm.css`. That file includes a rule like this:

```css
.markdown-body li + li {
  margin-top: ...
}
```

Which gives every lint rule item except the first a top margin. When filtering the rule list the first item is often hidden, which means that the first _visible_ item got a margin top and moved the result list around.