### PR TITLE
fix: correct code block from reference docs

### DIFF
--- a/_includes/renderCommand.tsx
+++ b/_includes/renderCommand.tsx
@@ -89,7 +89,7 @@ export default function renderCommand(
 
         while (offset > 0) {
           line = lines.shift();
-          offset -= line.length;
+          offset -= line.length + 1;
         }
 
         if (START_AND_END_ANSI_RE.test(line.trim())) {


### PR DESCRIPTION
There is a bug in calculating whether to use inline or pre code blocks.

Example: https://docs.deno.com/runtime/reference/cli/install/
<img width="673" alt="image" src="https://github.com/user-attachments/assets/f5836212-3eac-4ca2-b67f-9e46a737f212" />

The offset is used to determine where the ANSI color block match is in the reference string. If the line is a full match, a pre code block is rendered, otherwise an inline code block is rendered.

Line 87 loses the linefeed characters used in the split. The calculation was deviating slightly from the correct offset as a result. In the edge case for the inline code block near the end of a line, its type is derived from the next line, and incorrectly when the next line is a pre block.

Fix:
<img width="671" alt="image" src="https://github.com/user-attachments/assets/1354640f-96eb-402c-aa11-d4667960817b" />

Tested by building locally, and spot checking other commands.