### PR TITLE
Additional example and description for setting en vars when running a script

### DIFF
--- a/runtime/reference/env_variables.md
+++ b/runtime/reference/env_variables.md
@@ -80,6 +80,9 @@ variable, and can be helpfully combined with
 
 ```json title="deno.json"
 {
+
+  ...
+  
   "tasks": {
     "build:full": {
       "description": "Build the site with all features",

--- a/runtime/reference/env_variables.md
+++ b/runtime/reference/env_variables.md
@@ -65,6 +65,34 @@ console.log(Deno.env.get("GREETING")); // "Hello, world."
 Further documentation for `.env` handling can be found in the
 [@std/dotenv](https://jsr.io/@std/dotenv/doc) documentation.
 
+## Set a variable when running a command
+
+As with other CLI commands, you can set environment variables before running a
+command like so:
+
+```shell
+MY_VAR="my value" deno run main.ts
+```
+
+This can be useful when you want to vary a task based on an environment
+variable, and can be helpfully combined with
+[`deno task`](/runtime/reference/cli/task/) commands like so:
+
+```json title="deno.json"
+{
+  "tasks": {
+    "build:full": {
+      "description": "Build the site with all features",
+      "command": "BUILD_TYPE=FULL deno run main.ts"
+    },
+    "build:light": {
+      "description": "Build the site without expensive operations",
+      "command": "BUILD_TYPE=LIGHT deno run main.ts"
+    }
+  }
+}
+```
+
 ## `std/cli`
 
 The Deno Standard Library has a [`std/cli` module](https://jsr.io/@std/cli) for


### PR DESCRIPTION
Address docs feedback:

> how to run deno tasks with envs set, it doesnt seem to appear when I call Deno.env.get(ENV_NAME)  

Adds more descption and an example with `deno task`