### PR TITLE
docs(completions): intro for those unfamiliar

### DIFF
--- a/runtime/reference/cli/completions.md
+++ b/runtime/reference/cli/completions.md
@@ -4,12 +4,16 @@ oldUrl: /runtime/manual/tools/completions/
 command: completions
 ---
 
+You can use the output script to configure autocompletion for `deno` commands.
+For example: `deno un` -> <kbd>Tab</kbd> -> `deno uninstall`.
+
 ## Examples
 
 ### Configure Bash shell completion
 
 ```bash
-deno completions bash > /usr/local/etc/bash_completion.d/deno.bash
+deno completions bash > deno.bash
+sudo mv deno.bash /usr/local/etc/bash_completion.d/
 source /usr/local/etc/bash_completion.d/deno.bash
 ```
 


### PR DESCRIPTION
This page might warrant more information on how to persist completions after reboot, given that [bash apparently doesn't reliably source the completion scripts](https://stackoverflow.com/questions/56389011/does-bash-source-bash-completion-files-in-usr-local-etc-bash-completion-d-by-de) from `/usr/local/etc/bash_completion.d`.