### PR TITLE
docs(completions): support other Linux distros

### DIFF
--- a/runtime/reference/cli/completions.md
+++ b/runtime/reference/cli/completions.md
@@ -13,8 +13,16 @@ For example: `deno un` -> <kbd>Tab</kbd> -> `deno uninstall`.
 
 ```bash
 deno completions bash > deno.bash
-sudo mv deno.bash /usr/local/etc/bash_completion.d/
-source /usr/local/etc/bash_completion.d/deno.bash
+
+if [ -d "/usr/local/etc/bash_completion.d/" ]; then
+  sudo mv deno.bash /usr/local/etc/bash_completion.d/
+  source /usr/local/etc/bash_completion.d/deno.bash
+elif [ -d "/usr/share/bash-completion/completions/" ]; then
+  sudo mv deno.bash /usr/share/bash-completion/completions/
+  source /usr/share/bash-completion/completions/deno.bash
+else
+  echo "Please move deno.bash to the appropriate bash completions directory"
+fi
 ```
 
 ### Configure PowerShell shell completion


### PR DESCRIPTION
On Fedora, bash completions live at `/usr/share/bash-completion/completions/`.