### PR TITLE
docs: fix typos

### DIFF
--- a/runtime/_data.ts
+++ b/runtime/_data.ts
@@ -386,7 +386,7 @@ This the data is read from the files in the reference_gen/node_description direc
 This function is called in node.md through the templating engine Vento,
 after which the normal markdown rendered is called.
  */
-export async function generateNodeCompatability() {
+export async function generateNodeCompatibility() {
   const descriptions = await generateDescriptions();
   const sorted = Object.entries(descriptions).toSorted(([keyA], [keyB]) =>
     keyA.localeCompare(keyB)

--- a/runtime/reference/cli/install.md
+++ b/runtime/reference/cli/install.md
@@ -43,8 +43,8 @@ to `deno.json`.
 
 ### deno install --entrypoint [FILES]
 
-Use this command to install all depenedencies that are used in the provided
-files and their dependencies.
+Use this command to install all dependencies that are used in the provided files
+and their dependencies.
 
 This is particularly useful if you use `jsr:`, `npm:`, `http:` or `https:`
 specifiers in your code and want to cache all the dependencies before deploying

--- a/runtime/reference/cli/task.md
+++ b/runtime/reference/cli/task.md
@@ -100,7 +100,7 @@ tasks.
 
 **When using a wildcard** make sure to quote the task name (eg. `"build-*"`),
 otherwise your shell might try to expand the wildcard character, leading to
-suprising errors.
+surprising errors.
 
 :::
 
@@ -337,7 +337,7 @@ sleep 1 && deno run --allow-net server.ts & deno run --allow-net client.ts
 
 Unlike in most shells, the first async command to fail will cause all the other
 commands to fail immediately. In the example above, this would mean that if the
-server command fails then the cleint command will also fail and exit. You can
+server command fails then the client command will also fail and exit. You can
 opt out of this behavior by adding `|| true` to the end of a command, which will
 force a `0` exit code. For example:
 

--- a/runtime/reference/cli/unstable_flags.md
+++ b/runtime/reference/cli/unstable_flags.md
@@ -95,7 +95,7 @@ globals are:
 - `setImmediate`
 - `clearImmediate`
 
-Note, that `process` is already available as a global startin with Deno 2.0.
+Note, that `process` is already available as a global starting with Deno 2.0.
 
 Requires Deno >= 2.1.0
 

--- a/runtime/reference/lint_plugins.md
+++ b/runtime/reference/lint_plugins.md
@@ -15,7 +15,7 @@ in the future.
 The built-in linter can be extended with plugins to add custom lint rules.
 
 Whilst Deno ships with [many lint rules](/lint/) out of the box, there are cases
-where you need a custom rule tailored particularily to your project - whether to
+where you need a custom rule tailored particularly to your project - whether to
 catch a context-specific problem or enforce company-wide conventions.
 
 This is where the lint plugin API comes into play.
@@ -128,7 +128,7 @@ supported syntax for selectors is:
 | `Foo > Bar`               | Child combinator                       |
 | `Foo ~ Bar`               | Subsequent sibling combinator          |
 | `Foo Bar`                 | Descendant combinator                  |
-| `Foo[attr]`               | Attribute existance                    |
+| `Foo[attr]`               | Attribute existence                    |
 | `Foo[attr.length < 2]`    | Attribute value comparison             |
 | `Foo[attr=/(foo\|bar)*/]` | Attribute value regex check            |
 | `:first-child`            | First child pseudo-class               |

--- a/runtime/reference/node_apis.md
+++ b/runtime/reference/node_apis.md
@@ -15,7 +15,7 @@ Node compatibility is an ongoing project - help us identify gaps and let us know
 which modules you need by
 [opening an issue on GitHub](https://github.com/denoland/deno).
 
-{{ await generateNodeCompatability() }}
+{{ await generateNodeCompatibility() }}
 
 ## Globals
 

--- a/runtime/reference/ts_config_migration.md
+++ b/runtime/reference/ts_config_migration.md
@@ -360,7 +360,7 @@ can be a fully qualified URL as well:
 /// <reference types="https://deno.land/x/pkg@1.0.0/types.d.ts" />
 ```
 
-### Suppling "types" in deno.json
+### Supplying "types" in deno.json
 
 Another option is to provide a `"types"` value to the `"compilerOptions"` in
 your `deno.json`. For example:


### PR DESCRIPTION
Two kinds of grammar fixes in this PR:

- `generateNodeCompatibility()` has been corrected, `...tability..` to `...tibility...`
- typos in markdown, in words

As always, don't hesitate to edit/change/cancel/request changes to this PR.