### PR TITLE
move tags to after codeblock

### DIFF
--- a/reference/_components/DocEntry.tsx
+++ b/reference/_components/DocEntry.tsx
@@ -31,8 +31,7 @@ export default function (
             className="font-medium"
             dangerouslySetInnerHTML={{ __html: docEntry.content }}
           />
-        </code>
-        {" "}
+        </code>{" "}
         {docEntry.tags && docEntry.tags.length > 0 && (
           <span>
             {docEntry.tags.map((tag, index) => (

--- a/reference/_components/DocEntry.tsx
+++ b/reference/_components/DocEntry.tsx
@@ -9,12 +9,6 @@ export default function (
       id={docEntry.id}
     >
       <div className="docEntryHeader">
-        {docEntry.tags && docEntry.tags.length > 0 && (
-          <div className="space-x-1 mb-1">
-            {docEntry.tags.map((tag) => <comp.Tag tag={tag} />)}
-          </div>
-        )}
-
         {/* Chosen 200 as a guestimate of when code is blocks rather than inline, would be better if this was in the markup sent from ddoc */}
         <code
           className={docEntry.content.length > 200 ? "inline-code-block" : ""}
@@ -38,6 +32,14 @@ export default function (
             dangerouslySetInnerHTML={{ __html: docEntry.content }}
           />
         </code>
+        {" "}
+        {docEntry.tags && docEntry.tags.length > 0 && (
+          <span>
+            {docEntry.tags.map((tag, index) => (
+              <comp.Tag key={index} tag={tag} />
+            ))}
+          </span>
+        )}
       </div>
 
       {/*markdown rendering*/}

--- a/static/reference_styles.css
+++ b/static/reference_styles.css
@@ -524,6 +524,12 @@
   margin-top: calc(0.5rem * calc(1 - var(--tw-space-y-reverse)));
   margin-bottom: calc(0.5rem * var(--tw-space-y-reverse));
 }
+
+.docEntryHeader {
+  display: flex;
+  gap: 1rem;
+}
+
 .ddoc .docEntry .docEntryHeader > div {
   overflow-wrap: break-word;
 }


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/f4bb0e7b-ac30-44cf-be74-949684c92c9a)

After:
![image](https://github.com/user-attachments/assets/33f2dde1-2610-4c05-bd35-9442ca52674e)

Fixes: https://github.com/denoland/docs/issues/1503