### PR TITLE
fix: render breadcrumbs last element as markdown

### DIFF
--- a/_components/Breadcrumbs.tsx
+++ b/_components/Breadcrumbs.tsx
@@ -37,7 +37,7 @@ export default function (props: {
   url: string;
   sectionTitle: string;
   sectionHref: string;
-}) {
+}, helpers: Lume.Helpers) {
   const crumbs: SidebarItem[] = [];
 
   for (const section of props.sidebar) {
@@ -99,9 +99,13 @@ export default function (props: {
                   </a>
                 )
                 : (
-                  <span itemprop="name" class="block px-3 py-1.5 text-sm">
-                    {crumb.title}
-                  </span>
+                  <span
+                    itemprop="name"
+                    class="block px-3 py-1.5 text-sm"
+                    dangerouslySetInnerHTML={{
+                      __html: helpers.md(crumb.title, true),
+                    }}
+                  />
                 )}
               <meta itemprop="position" content={String(i + 2)} />
             </li>


### PR DESCRIPTION

<img width="679" alt="Screenshot 2025-03-14 at 12 56 11" src="https://github.com/user-attachments/assets/87c43d14-c15f-4010-9e36-5faf0e3b1e36" />

Localhost: http://localhost:3000/runtime/reference/cli/bench/
Prod: https://docs.deno.com/runtime/reference/cli/bench/

Implementation is as per Lume maintainers' [recommendation](https://github.com/lumeland/lume/issues/739).

Previously, markdown in titles ended up in breadcrumb, with backticks visible on `<code>` pieces.
No more!
Feel free to edit, change, reject, close, take over — whatever is best for the project.