### PR TITLE
fix: deno serve example with json conditional

### DIFF
--- a/runtime/reference/cli/serve.md
+++ b/runtime/reference/cli/serve.md
@@ -32,7 +32,7 @@ types of requests and serve content accordingly:
 ```typescript title="server.ts"
 export default {
   async fetch(request) {
-    if (request.url.startsWith("/json")) {
+    if (request.url.endsWith("/json")) {
       return Response.json({ hello: "world" });
     }
 


### PR DESCRIPTION
`request.url` is returning a full url: `http://localhost:3000/json`
`startsWith` wont match, but `endsWith` does