### PR TITLE
remove ToC from docs, it doesnt add to usability

### DIFF
--- a/examples/tutorials/mocking.md
+++ b/examples/tutorials/mocking.md
@@ -4,23 +4,9 @@ description: "Master the art of mocking in your unit tests. Learn how spies, stu
 url: /examples/mocking_tutorial/
 ---
 
-# Testing in isolation with mocks
-
 This guide builds on the
 [basics of testing in Deno](/examples/testing_tutorial/) to focus specifically
 on mocking techniques that help you isolate your code during testing.
-
-## Table of Contents
-
-- [Introduction](#introduction)
-- [Spying](#spying)
-- [Stubbing](#stubbing)
-- [Faking time](#faking-time)
-- [Advanced mocking patterns](#advanced-mocking-patterns)
-- [Real-world example](#real-world-example)
-- [Summary](#summary)
-
-## Introduction
 
 For effective unit testing, you'll often need to "mock" the data that your code
 interacts with. Mocking is a technique used in testing where you replace real

--- a/examples/tutorials/testing.md
+++ b/examples/tutorials/testing.md
@@ -1,5 +1,5 @@
 ---
-title: "Writing tests in Deno: A complete guide"
+title: "Writing tests"
 description: "Learn key concepts like test setup and structure, assertions, async testing, mocking, test fixtures, and code coverage"
 url: /examples/testing_tutorial/
 ---
@@ -8,18 +8,6 @@ Testing is critical in software development to ensure your code works as
 expected, and continues to work as you make changes. Tests verify that your
 functions, modules, and applications behave correctly, handle edge cases
 appropriately, and maintain expected performance characteristics.
-
-## Table of Contents
-
-- [Why testing matters](#why-testing-matters)
-- [Writing tests with `Deno.test`](#writing-tests-with-denotest)
-- [Test structure and organization](#test-structure-and-organization)
-- [Assertions](#assertions)
-- [Async testing](#async-testing)
-- [Mocking in tests](#mocking-in-tests)
-- [Coverage](#coverage)
-- [Comparison with other testing frameworks](#comparison-with-other-testing-frameworks)
-- [Next steps](#next-steps)
 
 ## Why testing matters
 


### PR DESCRIPTION
shorten title
remove toc, doesn't actually improve usability 