### PR TITLE
fix: Cron configuration example

### DIFF
--- a/deploy/kv/manual/cron.md
+++ b/deploy/kv/manual/cron.md
@@ -158,8 +158,8 @@ Deno.cron("Run every fifteen minutes", "*/15 * * * *", () => {
 });
 ```
 
-```ts title="Run once an hour, on the hour"
-Deno.cron("Run once an hour, on the hour", "0 * * * *", () => {
+```ts title="Run once an hour on the hour"
+Deno.cron("Run once an hour on the hour", "0 * * * *", () => {
   console.log("Hello, cron!");
 });
 ```


### PR DESCRIPTION
This PR fixes Cron configuration example `Run once an hour, on the hour`

```
Deno.cron("Run once an hour, on the hour", "0 * * * *", () => {
  console.log("Hello, cron!");
});
```

Copying this example will cause an error as this is an invalid cron name (`,` is not allowed).

<img width="985" alt="Screenshot 2025-03-27 at 15 39 37" src="https://github.com/user-attachments/assets/ef80acab-1e84-444d-8838-46d32a48ddb3" />
