### PR TITLE
update lambda tutorial to use most recent aws adapter

### DIFF
--- a/examples/tutorials/aws_lambda.md
+++ b/examples/tutorials/aws_lambda.md
@@ -33,7 +33,7 @@ Create a new file named `Dockerfile` with the following content:
 
 ```Dockerfile
 # Set up the base image
-FROM public.ecr.aws/awsguru/aws-lambda-adapter:0.8.4 AS aws-lambda-adapter
+FROM public.ecr.aws/awsguru/aws-lambda-adapter:0.9.0 AS aws-lambda-adapter
 FROM denoland/deno:bin-1.45.2 AS deno_bin
 FROM debian:bookworm-20230703-slim AS deno_runtime
 COPY --from=aws-lambda-adapter /lambda-adapter /opt/extensions/lambda-adapter

--- a/examples/videos/deploy_deno_to_aws_lambda.md
+++ b/examples/videos/deploy_deno_to_aws_lambda.md
@@ -32,7 +32,7 @@ Let’s take a look at the Dockerfile that we can use to make this work:
 
 ```dockerfile
 # Set up the base image
-FROM public.ecr.aws/awsguru/aws-lambda-adapter:0.8.4 AS aws-lambda-adapter
+FROM public.ecr.aws/awsguru/aws-lambda-adapter:0.9.0 AS aws-lambda-adapter
 FROM denoland/deno:bin-2.0.2 AS deno_bin
 FROM debian:bookworm-20230703-slim AS deno_runtime
 COPY --from=aws-lambda-adapter /lambda-adapter /opt/extensions/lambda-adapter


### PR DESCRIPTION
Tested both tutorials with updated adapter, works well

![image](https://github.com/user-attachments/assets/565a0375-8c65-4761-a3c7-b33af1af8c4f)
