### PR TITLE
docs: fix docker healthcheck example

### DIFF
--- a/runtime/reference/docker.md
+++ b/runtime/reference/docker.md
@@ -151,7 +151,7 @@ services:
 
 ```dockerfile
 HEALTHCHECK --interval=30s --timeout=3s \
-  CMD deno eval "try { await fetch('http://localhost:8000/health'); } catch { exit(1); }"
+  CMD deno eval "try { await fetch('http://localhost:8000/health'); } catch { Deno.exit(1); }"
 ```
 
 ### Common Development Workflow


### PR DESCRIPTION
Before:

```sh
deno eval "try { await fetch('http://localhost:8000/health'); } catch { exit(1); }"
error: Uncaught (in promise) ReferenceError: exit is not defined
try { await fetch('http://localhost:8000/health'); } catch { exit(1); }
                                                             ^
    at file:///Users/torstendittmann/Documents/GitHub/TorstenDittmann/contained/$deno$eval.mts:1:62
    at eventLoopTick (ext:core/01_core.js:178:7)
```

Using `Deno.exit(1)` will make this work 👍🏻 