### PR TITLE
docs(linting): add ignore custom plugin rules section

### DIFF
--- a/runtime/reference/lint_plugins.md
+++ b/runtime/reference/lint_plugins.md
@@ -255,6 +255,23 @@ custom lint rule is always `<plugin-name>/<rule-name>`.
 }
 ```
 
+## Ignoring custom lint reports
+
+Sometimes you want to disable a reported lint error for a particular place in your code. Instead of disabling the custom lint rule entirely, you can disable a reported location by placing a code comment before it.
+
+```ts
+// deno-lint-ignore my-custom-plugin/no-console
+console.log("hey");
+```
+
+This will disable the lint rule from a lint plugin for this particular line.
+
+The syntax for the ignore comment is:
+
+```ts
+// deno-lint-ignore <my-plugin>/<my-rule>
+```
+
 ## Testing plugins
 
 The `Deno.lint.runPlugin` API provides a convenient way to test your plugins. It
@@ -271,7 +288,7 @@ Deno.test("my-plugin", () => {
   const diagnostics = Deno.lint.runPlugin(
     myPlugin,
     "main.ts", // Dummy filename, file doesn't need to exist.
-    "const _a = 'a';",
+    "const _a = 'a';"
   );
 
   assertEquals(diagnostics.length, 1);


### PR DESCRIPTION
The document for custom lint plugin rules didn't mention that you can disable reports with standard comments.

```ts
// deno-lint-ignore my-custom-plugin/no-console
console.log("hey");
```

Fixes https://github.com/denoland/docs/issues/1605