### PR TITLE
Updates Helix languages.toml

### DIFF
--- a/runtime/getting_started/setup_your_environment.md
+++ b/runtime/getting_started/setup_your_environment.md
@@ -341,12 +341,14 @@ Enabling connection to the Deno language server requires changes in the
 [[language]]
 name = "typescript"
 roots = ["deno.json", "deno.jsonc", "package.json"]
+file-types = ["ts", "tsx"]
 auto-format = true
 language-servers = ["deno-lsp"]
 
 [[language]]
 name = "javascript"
 roots = ["deno.json", "deno.jsonc", "package.json"]
+file-types = ["js", "jsx"]
 auto-format = true
 language-servers = ["deno-lsp"]
 


### PR DESCRIPTION
Without `file-types` the LSP does not work with Deno 2.2.8 in Helix 25.01.1