### PR TITLE
docs: Update coverage ignore docs

### DIFF
--- a/runtime/reference/cli/coverage.md
+++ b/runtime/reference/cli/coverage.md
@@ -77,21 +77,29 @@ if (condition) {
 ```
 
 All code after a `// deno-coverage-ignore-start` comment is ignored until a
-`// deno-coverage-ignore-stop` is reached. However, if there are multiple
-consecutive start comments, each of these must be terminated by a corresponding
-stop comment.
+`// deno-coverage-ignore-stop` is reached.
+
+Each `// deno-coverage-ignore-start` comment must be terminated by a
+`// deno-coverage-ignore-stop` comment, and ignored ranges may not be nested.
+When these requirements are not met, some lines may be unintentionally included
+in the coverage report. The `deno coverage` command will log warnings for any
+invalid comments.
 
 ```ts
 // deno-coverage-ignore-start
 if (condition) {
-  // deno-coverage-ignore-start
-  console.log("this line is ignored");
+  // deno-coverage-ignore-start - A warning will be logged because the previous
+  //                              coverage range is unterminated.
+  console.log("this code is ignored");
   // deno-coverage-ignore-stop
-  console.log("this line is also ignored");
 }
 // deno-coverage-ignore-stop
 
-console.log("this line is not ignored");
+// ...
+
+// deno-coverage-ignore-start - This comment will be ignored and a warning will
+//                              be logged, because this range is unterminated.
+console.log("this code is not ignored");
 ```
 
 Only white space may precede the coverage directive in a coverage comment.

--- a/runtime/reference/cli/coverage.md
+++ b/runtime/reference/cli/coverage.md
@@ -57,8 +57,8 @@ top of the file.
 
 Ignored files will not appear in the coverage report.
 
-To ignore a single line, add a `// deno-coverage-ignore` comment on the
-line above the code you want to ignore.
+To ignore a single line, add a `// deno-coverage-ignore` comment on the line
+above the code you want to ignore.
 
 ```ts
 // deno-coverage-ignore

--- a/runtime/reference/cli/coverage.md
+++ b/runtime/reference/cli/coverage.md
@@ -57,11 +57,11 @@ top of the file.
 
 Ignored files will not appear in the coverage report.
 
-To ignore a single line, add a `// deno-coverage-ignore-next` comment on the
+To ignore a single line, add a `// deno-coverage-ignore` comment on the
 line above the code you want to ignore.
 
 ```ts
-// deno-coverage-ignore-next
+// deno-coverage-ignore
 console.log("this line is ignored");
 ```
 
@@ -98,10 +98,10 @@ Only white space may precede the coverage directive in a coverage comment.
 However, any text may trail the directive.
 
 ```ts
-// deno-coverage-ignore-next Trailing text is allowed.
+// deno-coverage-ignore Trailing text is allowed.
 console.log("This line is ignored");
 
-// But leading text isn't. deno-coverage-ignore-next
+// But leading text isn't. deno-coverage-ignore
 console.log("This line is not ignored");
 ```
 
@@ -109,10 +109,10 @@ Coverage comments must start with `//`. Comments starting with `/*` are not
 valid coverage comments.
 
 ```ts
-// deno-coverage-ignore-next
+// deno-coverage-ignore
 console.log("This line is ignored");
 
-/* deno-coverage-ignore-next */
+/* deno-coverage-ignore */
 console.log("This line is not ignored");
 ```
 


### PR DESCRIPTION
Since https://github.com/denoland/docs/pull/1121 was merged, there have been some changes to the `// deno-coverage-ignore*` comments, including the following:

- Removing the `-next` suffix for `// deno-coverage-ignore`
- Adding warnings for nested ignore ranges
- Adding warnings for unterminated ignore ranges

This PR updates the docs for `deno coverage` to match the latest behavior.

See https://github.com/denoland/deno/pull/26590