### PR TITLE
Add reference to Node test result viewer

### DIFF
--- a/runtime/contributing/index.md
+++ b/runtime/contributing/index.md
@@ -35,6 +35,12 @@ Some systems, including a large part of the Node.js compatibility layer are
 implemented in JavaScript and TypeScript modules. These are a good place to
 start if you are looking to make your first contribution.
 
+[Here](https://node-test-viewer.deno.dev/results/latest) is a list of Node.js
+test cases, including both successful and failing ones. Reviewing these can
+provide valuable insight into how the compatibility layer works in practice, and
+where improvements might be needed. They can also serve as a useful guide for
+identifying areas where contributions are most impactful.
+
 While iterating on such modules it is recommended to include `--features hmr` in
 your `cargo` flags. This is a special development mode where the JS/TS sources
 are not included in the binary but read at runtime, meaning the binary will not

--- a/runtime/reference/node_apis.md
+++ b/runtime/reference/node_apis.md
@@ -96,3 +96,9 @@ importing them from the relevant `node:` module.
 | [`WritableStream`](https://nodejs.org/api/globals.html#class-writablestream)                                     | ✅                                 |
 | [`WritableStreamDefaultController`](https://nodejs.org/api/globals.html#class-writablestreamdefaultcontroller)   | ✅                                 |
 | [`WritableStreamDefaultWriter`](https://nodejs.org/api/globals.html#class-writablestreamdefaultwriter)           | ✅                                 |
+
+## Node test results
+
+If you're interested in a more detailed view of compatibility on a per-test-case
+basis, you can find a list of both passing and failing Node.js test cases on
+[this page](https://node-test-viewer.deno.dev/).


### PR DESCRIPTION
We have started tracking the passing and failing Node.js test cases in [this page](https://node-test-viewer.deno.dev/results/latest). ref https://github.com/denoland/deno/issues/28318

This PR adds the reference to that page to ensure contributors are aware of it