### PR TITLE
add async to setup next step of example

### DIFF
--- a/examples/tutorials/file_server.md
+++ b/examples/tutorials/file_server.md
@@ -21,7 +21,7 @@ incoming requests. In your new `file-server.ts` file, add the following code:
 ```ts title="file-server.ts"
 Deno.serve(
   { hostname: "localhost", port: 8080 },
-  (request) => {
+  async (request) => {
     const url = new URL(request.url);
     const filepath = decodeURIComponent(url.pathname);
   },


### PR DESCRIPTION
Adds `async` to handler function in order for next step of example to work correctly.

https://docs.deno.com/examples/file_server_tutorial/