### PR TITLE
Feedback clarifications

### DIFF
--- a/deploy/manual/postgres.md
+++ b/deploy/manual/postgres.md
@@ -74,11 +74,12 @@ environment variables:
 
 ## Write code that connects to Postgres
 
-To read/write to Postgres, import the Postgres module, read the connection
+To read/write to Postgres, import a suitable Postgres module such as
+[this one from JSR](https://jsr.io/@bartlomieju/postgres), read the connection
 string from the environment variables, and create a connection pool.
 
 ```ts
-import { Pool } from "https://deno.land/x/postgres@v0.17.0/mod.ts";
+import { Pool } from "jsr:@bartlomieju/postgres";
 
 // Get the connection string from the environment variable "DATABASE_URL"
 const databaseUrl = Deno.env.get("DATABASE_URL")!;

--- a/examples/videos/deploying_deno_with_docker.md
+++ b/examples/videos/deploying_deno_with_docker.md
@@ -14,6 +14,7 @@ environment.
 
 - https://github.com/denoland/deno_docker
 - https://fly.io/
+- https://docs.deno.com/runtime/reference/docker/
 
 ## Transcript and code
 
@@ -164,3 +165,9 @@ at that location.
 
 So with Deno, we can use Docker to containerize the app and with Fly we can get
 the app hosted in production in just a few minutes.
+
+## More information on working with Docker
+
+For a closer look at Deno's support of Docker, including best practices, running
+tests with Docker, using workspaces, and more, please take a look at our
+[Deno and Docker reference documentation](https://docs.deno.com/runtime/reference/docker/).

--- a/runtime/fundamentals/workspaces.md
+++ b/runtime/fundamentals/workspaces.md
@@ -206,6 +206,9 @@ import workspace dependencies.
 
 ### Multiple package entries
 
+The `exports` property details the entry points and exposes which modules should
+be importable by users of your package.
+
 So far, our package only has a single entry. This is fine for simple packages,
 but often you'll want to have multiple entries that group relevant aspects of
 your package. This can be done by passing an `object` instead of a `string` to

--- a/runtime/getting_started/setup_your_environment.md
+++ b/runtime/getting_started/setup_your_environment.md
@@ -356,6 +356,11 @@ args = ["lsp"]
 config.deno.enable = true
 ```
 
+### Zed
+
+The [Zed editor](https://zed.dev) can integrate the Deno language server via the
+[Deno extension](https://zed.dev/extensions?query=deno&filter=language-servers).
+
 ## Shell completions
 
 Built into the Deno CLI is support to generate shell completion information for

--- a/runtime/reference/cli/publish.md
+++ b/runtime/reference/cli/publish.md
@@ -15,7 +15,9 @@ Your package must have a `name` and `version` and an `exports` field in its
 - The `name` field must be unique and follow the `@<scope_name>/<package_name>`
   convention.
 - The `version` field must be a valid semver version.
-- The `exports` field must point to the main entry point of the package.
+- The `exports` field must point to the main entry point of the package. The
+  exports field can either be specified as a single string, or as an object
+  mapping entrypoint names to paths in your package.
 
 Example:
 

--- a/runtime/reference/cli/repl.md
+++ b/runtime/reference/cli/repl.md
@@ -154,6 +154,10 @@ readTextFileSync  readFileSync      readDir           readLink          readAllS
 
 ## `DENO_REPL_HISTORY`
 
+By default, Deno stores REPL history in a `deno_history.txt` file within the
+`DENO_DIR` directory. The location of your `DENO_DIR` directory and other
+resources, can be found by running the `deno info`.
+
 You can use `DENO_REPL_HISTORY` environmental variable to control where Deno
 stores the REPL history file. You can set it to an empty value, Deno will not
 store the history file.


### PR DESCRIPTION
A selection of small updates to docs addressing specific feedback and questions

- Describe default location of deno REPL history
- Describe LSP support for Zed
- Links to more onfo on using docker
- mention that deno.json exports can be string or object
- add description of what export property is for
- replace http import with JSR in this example