### PR TITLE
Document DENO_COVERAGE_DIR env var

### DIFF
--- a/runtime/reference/cli/coverage.md
+++ b/runtime/reference/cli/coverage.md
@@ -157,6 +157,14 @@ deno test --coverage=custom_profile_name
 deno coverage custom_profile_name
 ```
 
+> Note: You can alternatively set coverage directory by `DENO_COVERAGE_DIR` env
+> var.
+>
+> ```
+> DENO_COVERAGE_DIR=custom_profile_name deno test
+> deno coverage custom_profile_name
+> ```
+
 Only include coverage that matches a specific pattern - in this case, only
 include tests from main.ts
 

--- a/runtime/reference/env_variables.md
+++ b/runtime/reference/env_variables.md
@@ -112,6 +112,7 @@ The Deno runtime has these special environment variables.
 | DENO_AUTH_TOKENS     | A semi-colon separated list of bearer tokens and hostnames to use when fetching remote modules from private repositories<br />(e.g. `abcde12345@deno.land;54321edcba@github.com`) |
 | DENO_TLS_CA_STORE    | Comma-separated list of order dependent certificate stores.<br />Possible values: `system`, `mozilla`. Defaults to `mozilla`.                                                     |
 | DENO_CERT            | Load certificate authority from PEM encoded file                                                                                                                                  |
+| DENO_COVERAGE_DIR    | Set the directory for collecting coverage profile data. This option only works for [`deno test` subcommand](/runtime/reference/cli/test/).                                        |
 | DENO_DIR             | Set the cache directory                                                                                                                                                           |
 | DENO_INSTALL_ROOT    | Set deno install's output directory (defaults to `$HOME/.deno/bin`)                                                                                                               |
 | DENO_REPL_HISTORY    | Set REPL history file path History file is disabled when the value is empty <br />(defaults to `$DENO_DIR/deno_history.txt`)                                                      |


### PR DESCRIPTION
This PR documents `DENO_COVERAGE_DIR` env var, implemented in https://github.com/denoland/deno/pull/28291

The feature will be shipped in Deno v2.3