### PR TITLE
Align typeparam description to TSDoc

### DIFF
--- a/runtime/reference/cli/doc.md
+++ b/runtime/reference/cli/doc.md
@@ -134,7 +134,7 @@ by JSDoc, TSDoc and TypeDoc:
   available.
 - [`callback`](https://jsdoc.app/tags-callback): define a callback.
 - [`template`/`typeparam`/`typeParam`](https://tsdoc.org/pages/tags/typeparam):
-  define a callback.
+  define a generic parameter.
 - [`prop`/`property`](https://jsdoc.app/tags-property): define a property on a
   symbol.
 - [`typedef`](https://jsdoc.app/tags-typedef): define a type.


### PR DESCRIPTION
## Summary
- Align description of `typeparam` tag to TSDoc

## Description
I noticed today while browsing the ["Supported Tags" section of `deno doc`](https://docs.deno.com/runtime/reference/cli/doc/#supported-tags) docs that "define a callback" seems to have been copypasta'd into the `typeparam` tag.

I updated this to match the description from the linked TSDoc page.