### PR TITLE
docs: Fix cron schedule backoff example

### DIFF
--- a/deploy/kv/manual/cron.md
+++ b/deploy/kv/manual/cron.md
@@ -48,10 +48,10 @@ will attempt to retry failed callbacks three times - after one second, five
 seconds, and then ten seconds.
 
 ```ts
-Deno.cron("Retry example", "* * * * *", () => {
-  throw new Error("Deno.cron will retry this three times, to no avail!");
-}, {
+Deno.cron("Retry example", "* * * * *", {
   backoffSchedule: [1000, 5000, 10000],
+}, () => {
+  throw new Error("Deno.cron will retry this three times, to no avail!");
 });
 ```
 


### PR DESCRIPTION
Currently the `Deno.cron` documentation for retrying failed runs ([Source](https://docs.deno.com/deploy/kv/manual/cron/#retrying-failed-runs)) shows a code snippet that is, I am assuming, out of date as it recommends setting the options object as the fourth parameter when in reality it should be the third parameter & the last parameter is always set to be the cron handler.
