### PR TITLE
Update duckdb example

### DIFF
--- a/examples/scripts/duckdb.ts
+++ b/examples/scripts/duckdb.ts
@@ -13,11 +13,19 @@
 
 import { DuckDBInstance } from "npm:@duckdb/node-api";
 
+// For graceful cleanup of resources
+using stack = new DisposableStack();
+
 const instance = await DuckDBInstance.create(":memory:");
 // Or you can specify a path to a persistent database
 // const instance = await DuckDBInstance.create("./my_duckdb.db");
 
+// Close the instance when `stack` gets out of scope
+stack.defer(() => instance.closeSync());
+
 const connection = await instance.connect();
+// Close the connection when `stack` gets out of scope
+stack.defer(() => connection.closeSync());
 
 // Simple select query
 const reader = await connection.runAndReadAll("select 10, 'foo'");

--- a/examples/scripts/duckdb.ts
+++ b/examples/scripts/duckdb.ts
@@ -16,14 +16,15 @@ import { DuckDBInstance } from "npm:@duckdb/node-api";
 // For graceful cleanup of resources
 using stack = new DisposableStack();
 
+// Create an in-memory database
 const instance = await DuckDBInstance.create(":memory:");
-// Or you can specify a path to a persistent database
-// const instance = await DuckDBInstance.create("./my_duckdb.db");
 
 // Close the instance when `stack` gets out of scope
 stack.defer(() => instance.closeSync());
 
+// Connect to the database
 const connection = await instance.connect();
+
 // Close the connection when `stack` gets out of scope
 stack.defer(() => connection.closeSync());
 

--- a/examples/scripts/duckdb.ts
+++ b/examples/scripts/duckdb.ts
@@ -4,7 +4,7 @@
  * @tags cli, deploy
  * @run --allow-read --allow-write --allow-env --allow-net --allow-ffi <url>
  * @resource {https://duckdb.org/} DuckDB - An in-process SQL OLAP database management system
- * @resource {https://www.npmjs.com/package/@duckdb/node-api} Official high-level API for DuckDB
+ * @resource {https://www.npmjs.com/package/@duckdb/node-api} npm:@duckdb/node-api
  * @group Databases
  *
  * Using Deno with DuckDB, you can connect to memory or a persistent

--- a/examples/scripts/duckdb.ts
+++ b/examples/scripts/duckdb.ts
@@ -3,34 +3,33 @@
  * @difficulty intermediate
  * @tags cli, deploy
  * @run --allow-read --allow-write --allow-env --allow-net --allow-ffi <url>
- * @resource {https://deno.land/x/duckdb} Deno DuckDB on deno.land/x
  * @resource {https://duckdb.org/} DuckDB - An in-process SQL OLAP database management system
- * @resource {https://github.com/suketa/ruby-duckdb?tab=readme-ov-file#pre-requisite-setup-linux} DuckDB Pre-requisite setup (Linux)
+ * @resource {https://www.npmjs.com/package/@duckdb/node-api} Official high-level API for DuckDB
  * @group Databases
  *
  * Using Deno with DuckDB, you can connect to memory or a persistent
  * database with a filename.
  */
 
-import { open } from "jsr:@divy/duckdb";
+import { DuckDBInstance } from "npm:@duckdb/node-api";
 
-// const db = open("./example.db");
-const db = open(":memory:");
+const instance = await DuckDBInstance.create(":memory:");
+// Or you can specify a path to a persistent database
+// const instance = await DuckDBInstance.create("./my_duckdb.db");
 
-const connection = db.connect();
+const connection = await instance.connect();
 
-for (const row of connection.stream("select 42 as number")) {
-  console.debug(`Row Number: ${row.number}`); // -> { number: 42 }
-}
+// Simple select query
+const reader = await connection.runAndReadAll("select 10, 'foo'");
+const rows = reader.getRows();
 
-const prepared = connection.prepare(
-  "SELECT ?::INTEGER AS number, ?::VARCHAR AS text;",
-);
+console.debug(rows); // [ [ 10, "foo" ] ]
 
-const result = prepared.query(1337, "foo"); // [{ number: 1337, text: 'foo' }]
+// Prepared statement
+const prepared = await connection.prepare("select $1, $2");
+prepared.bindInteger(1, 20);
+prepared.bindVarchar(2, "bar");
+const reader2 = await prepared.runAndReadAll();
+const rows2 = reader2.getRows();
 
-console.debug(`Number: ${result[0].number}`);
-console.debug(`Text: ${result[0].text}`);
-
-connection.close();
-db.close();
+console.debug(rows2); // [ [ 20, "bar" ] ]


### PR DESCRIPTION
People told me that DuckDB example is outdated and not working now, and I confirmed it is the case:

```sh
➜ deno run --allow-read --allow-write --allow-env --allow-net --allow-ffi https://docs.deno.com/examples/scripts/duckdb.ts
error: Uncaught (in promise) Error: Could not open library: Could not open library: libduckdb.so: cannot open shared object file: No such file or directory
  return Deno.dlopen<S>(await download(options), symbols as any);
              ^
    at new DynamicLibrary (ext:deno_ffi/00_ffi.js:456:42)
    at Object.dlopen (ext:deno_ffi/00_ffi.js:562:10)
    at dlopen (https://jsr.io/@divy/plug/1.0.3/mod.ts:155:15)
    at eventLoopTick (ext:core/01_core.js:178:7)
    at async https://jsr.io/@divy/duckdb/0.2.1/lib.js:41:27
```

Then, after some exploration, now the official Node-API binding library just works with Deno, and it is well maintained and provides lots of good functionalities, so it'd be great to show the example code using this library.

## Test

This new example code works fine:

```sh
❯ deno run --allow-ffi examples/scripts/duckdb.ts
[ [ 10, "foo" ] ]
[ [ 20, "bar" ] ]
```