### PR TITLE
Add back "Prefer top level function declaration" rule with some reasoning

### DIFF
--- a/runtime/contributing/style_guide.md
+++ b/runtime/contributing/style_guide.md
@@ -363,6 +363,11 @@ export function foo(): string {
 }
 ```
 
+Regular functions and arrow functions have different behavior with respect to
+hoisting, binding, arguments, and constructability. The `function` keyword
+clearly indicates the intent to define a function, improving legibility and
+tracibility while debugging.
+
 #### Error Messages
 
 User-facing error messages raised from JavaScript / TypeScript should be clear,

--- a/runtime/contributing/style_guide.md
+++ b/runtime/contributing/style_guide.md
@@ -342,6 +342,27 @@ Deno.test("foo() returns bar object", function () {
 Note: See [tracking issue](https://github.com/denoland/deno_std/issues/3754) for
 more information.
 
+#### Top-level functions should not use arrow syntax
+
+Top-level functions should use the `function` keyword. Arrow syntax should be
+limited to closures.
+
+Bad:
+
+```ts
+export const foo = (): string => {
+  return "bar";
+};
+```
+
+Good:
+
+```ts
+export function foo(): string {
+  return "bar";
+}
+```
+
 #### Error Messages
 
 User-facing error messages raised from JavaScript / TypeScript should be clear,


### PR DESCRIPTION
We still prefer and are comfortable with this rule. I think we should keep this rule in the style guide.