### PR TITLE
move mdx files back to md

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -72,8 +72,10 @@
     "npm:jose@5.9.6": "5.9.6",
     "npm:markdown-it-anchor@9": "9.2.0_@types+markdown-it@14.1.2_markdown-it@14.1.0",
     "npm:markdown-it-attrs@4.2.0": "4.2.0_markdown-it@14.1.0",
+    "npm:markdown-it-container@*": "4.0.0",
     "npm:markdown-it-deflist@3.0.0": "3.0.0",
     "npm:markdown-it-emoji@3": "3.0.0",
+    "npm:markdown-it@*": "14.1.0",
     "npm:markdown-it@14.1.0": "14.1.0",
     "npm:meriyah@6.0.3": "6.0.3",
     "npm:mongodb@6.1.0": "6.1.0",
@@ -1689,6 +1691,9 @@
       "dependencies": [
         "markdown-it"
       ]
+    },
+    "markdown-it-container@4.0.0": {
+      "integrity": "sha512-HaNccxUH0l7BNGYbFbjmGpf5aLHAMTinqRZQAEQbMr2cdD3z91Q6kIo1oUn1CQndkT03jat6ckrdRYuwwqLlQw=="
     },
     "markdown-it-deflist@3.0.0": {
       "integrity": "sha512-OxPmQ/keJZwbubjiQWOvKLHwpV2wZ5I3Smc81OjhwbfJsjdRrvD5aLTQxmZzzePeO0kbGzAo3Krk4QLgA8PWLg=="

--- a/runtime/reference/deno_namespace_apis.md
+++ b/runtime/reference/deno_namespace_apis.md
@@ -14,7 +14,7 @@ The global `Deno` namespace contains APIs that are not web standard, including
 APIs for reading from files, opening TCP sockets, serving HTTP, and executing
 subprocesses, etc.
 
-<comp.CTA href="/api/deno" type="runtime">Explore all Deno APIs</comp.CTA>
+<a href="/api/deno/" class="docs-cta runtime-cta">Explore all Deno APIs</a>
 
 Below we highlight some of the most important Deno APIs to know.
 

--- a/runtime/reference/web_platform_apis.md
+++ b/runtime/reference/web_platform_apis.md
@@ -15,7 +15,7 @@ means if you've ever built for the browser, you're likely already familiar with
 Deno, and if you're learning Deno, you're also investing in your knowledge of
 the web.
 
-<comp.CTA href="/api/web" type="runtime">Explore supported Web APIs</comp.CTA>
+<a href="/api/web/" class="docs-cta runtime-cta">Explore supported Web APIs</a>
 
 Below we'll highlight some of the standard Web APIs that Deno supports.
 


### PR DESCRIPTION
Unfortunately, the Title and ToC plugins we're using do not work with mdx.  This means that any pages that are mdx files do not get the table of contents or the headings with anchor tags.

 We will have to re-evaluate how we add more complicated components to the markdown. For now I have swapped the files back to .md files and just thrown some html in there to render the CTAs. 

I imagine the fix might be to make our own markdown-it plugins to render custom components.