### PR TITLE
fix examples for deno fmt and Node.js fs imports

### DIFF
--- a/examples/videos/deno_fmt.md
+++ b/examples/videos/deno_fmt.md
@@ -105,9 +105,11 @@ const foo = [
 `deno fmt` can also reduce the escaped characters in your strings. For example,
 if you have a string with escaped quotes, `deno fmt` will remove them:
 
+<!-- deno-fmt-ignore-start -->
 ```typescript
-console.log('hello "world"');
+console.log("hello \"world\"");
 ```
+<!-- deno-fmt-ignore-end -->
 
 will be formatted to:
 

--- a/examples/videos/deno_fmt.md
+++ b/examples/videos/deno_fmt.md
@@ -39,7 +39,7 @@ deno fmt
 You could even pipe in a string or file:
 
 ```sh
-echo ' console.log(    5  );' | deno fmt
+echo ' console.log(    5  );' | deno fmt -
 ## console.log(5);
 ```
 
@@ -48,8 +48,8 @@ formatted by `deno fmt`. If it's not formatted, it will return a nonzero exit
 code:
 
 ```sh
-echo 'deno fmt --check
-## error: Found 1 not formatted file in 1 files
+echo ' console.log(    5  );' | deno fmt --check -
+## Not formatted stdin
 ```
 
 This is useful in CI where you want to check if the code is formatted properly.

--- a/examples/videos/interoperability_with_nodejs.md
+++ b/examples/videos/interoperability_with_nodejs.md
@@ -19,7 +19,7 @@ Node. For example, we can use the core Node.js built in APIs. All we have to do
 is add this Node specifier here.
 
 ```ts
-import { fs } from "node:fs/promises";
+import fs from "node:fs/promises";
 ```
 
 Deno also supports the use of NPM modules. All you need to do is add the NPM


### PR DESCRIPTION
This PR fixes several documentation issues:

1. Added the missing stdin indicator ("-") in the deno fmt pipe examples, which
   is required when passing content through stdin.
2. Corrected the Node.js fs import syntax in the interoperability example to use
   the proper default import pattern.
3. Fixed the escaped quotes example in the deno_fmt documentation to correctly
   show the initial string with escaped quotes before formatting.

Special thanks to Johan Dahl for bringing these issues to our attention via
email.

