### PR TITLE
state that no upload request limits exist

### DIFF
--- a/deploy/manual/pricing-and-limits.md
+++ b/deploy/manual/pricing-and-limits.md
@@ -24,7 +24,7 @@ Applications have a maximum memory allocation of 512MB
 ## Upload request limits
 
 We do not set a limit for the number of upload requests your application may
-handle as long as your application is within our
+handle as long as your application is within
 [our acceptable use policy](/deploy/manual/acceptable-use-policy).
 
 ## TLS proxying

--- a/deploy/manual/pricing-and-limits.md
+++ b/deploy/manual/pricing-and-limits.md
@@ -21,6 +21,12 @@ deployment (source files and static files) **should not exceed 1 gigabyte**.
 
 Applications have a maximum memory allocation of 512MB
 
+## Upload request limits
+
+We do not set a limit for the number of upload requests your application may
+handle as long as your application is wirthin our
+[our acceptable use policy](/deploy/manual/acceptable-use-policy).
+
 ## TLS proxying
 
 TLS termination is required for outgoing connections to port 443 (the port used

--- a/deploy/manual/pricing-and-limits.md
+++ b/deploy/manual/pricing-and-limits.md
@@ -24,7 +24,7 @@ Applications have a maximum memory allocation of 512MB
 ## Upload request limits
 
 We do not set a limit for the number of upload requests your application may
-handle as long as your application is wirthin our
+handle as long as your application is within our
 [our acceptable use policy](/deploy/manual/acceptable-use-policy).
 
 ## TLS proxying


### PR DESCRIPTION
Update to `/deploy/manual/pricing-and-limits/`

closes #1705 