### PR TITLE
Fix Astro init command

### DIFF
--- a/examples/tutorials/astro.md
+++ b/examples/tutorials/astro.md
@@ -31,7 +31,7 @@ can start from scratch, and skip installing dependencies so we can install them
 with Deno later:
 
 ```jsx
-deno -A npm:create-astro@latest
+deno init --npm astro@latest
 
  astro   Launch sequence initiated.
 


### PR DESCRIPTION
The commands in the doc for creating an Astro project don't match. This PR fixes that in favor of the command that's closer to the one in the [Astro docs](https://docs.astro.build/en/install-and-setup/).