### PR TITLE
Add information about the `patch` field in `deno.json`

### DIFF
--- a/runtime/fundamentals/configuration.md
+++ b/runtime/fundamentals/configuration.md
@@ -130,7 +130,9 @@ import map's URL or file path.
 
 ### Overriding packages
 
-The `patch` field in `deno.json` allows you to override dependencies without modifying their source code. It also allows you to use packages stored locally on disk.
+The `patch` field in `deno.json` allows you to override dependencies without
+modifying their source code. It also allows you to use packages stored locally
+on disk.
 
 This capability addresses several common development challenges:
 
@@ -147,7 +149,11 @@ This capability addresses several common development challenges:
 }
 ```
 
-The package being referenced doesn't need to be published at all. It just needs to have the proper package metadata in `deno.json` or `package.json`, so that Deno knows what package it's dealing with. This provides greater flexibility and modularity, maintaining clean separation between your main code and external packages.
+The package being referenced doesn't need to be published at all. It just needs
+to have the proper package metadata in `deno.json` or `package.json`, so that
+Deno knows what package it's dealing with. This provides greater flexibility and
+modularity, maintaining clean separation between your main code and external
+packages.
 
 ## Tasks
 

--- a/runtime/fundamentals/configuration.md
+++ b/runtime/fundamentals/configuration.md
@@ -128,6 +128,27 @@ import { MyUtil } from "/util.ts";
 This causes import specifiers starting with `/` to be resolved relative to the
 import map's URL or file path.
 
+### Overriding packages
+
+The `patch` field in `deno.json` allows you to override dependencies without modifying their source code. It also allows you to use packages stored locally on disk.
+
+This capability addresses several common development challenges:
+
+- Dependency bug fixes
+- Private local libraries
+- Compatibility issues
+- Security concerns
+
+```json title="deno.json"
+{
+  "patch": [
+    "../some-package"
+  ]
+}
+```
+
+The package being referenced doesn't need to be published at all. It just needs to have the proper package metadata in `deno.json` or `package.json`, so that Deno knows what package it's dealing with. This provides greater flexibility and modularity, maintaining clean separation between your main code and external packages.
+
 ## Tasks
 
 The `tasks` field in your `deno.json` file is used to define custom commands

--- a/runtime/fundamentals/configuration.md
+++ b/runtime/fundamentals/configuration.md
@@ -134,13 +134,6 @@ The `patch` field in `deno.json` allows you to override dependencies without
 modifying their source code. It also allows you to use packages stored locally
 on disk.
 
-This capability addresses several common development challenges:
-
-- Dependency bug fixes
-- Private local libraries
-- Compatibility issues
-- Security concerns
-
 ```json title="deno.json"
 {
   "patch": [
@@ -149,11 +142,18 @@ This capability addresses several common development challenges:
 }
 ```
 
+This capability addresses several common development challenges:
+
+- Dependency bug fixes
+- Private local libraries
+- Compatibility issues
+- Security concerns
+
 The package being referenced doesn't need to be published at all. It just needs
-to have the proper package metadata in `deno.json` or `package.json`, so that
-Deno knows what package it's dealing with. This provides greater flexibility and
-modularity, maintaining clean separation between your main code and external
-packages.
+to have the proper package name and metadata in `deno.json` or `package.json`,
+so that Deno knows what package it's dealing with. This provides greater
+flexibility and modularity, maintaining clean separation between your main code
+and external packages.
 
 ## Tasks
 


### PR DESCRIPTION
Though some of the `patch` feature seems to be unstable (NPM patching), patching local dependencies looked stable to me. Writing this in the docs will allow developers to provide more feedback on it.

Related:

- https://github.com/denoland/deno/pull/25068
- https://github.com/denoland/deno/issues/25110