### PR TITLE
Introduce `links` instead of `patch` in `deno.json` docs

### DIFF
--- a/runtime/fundamentals/configuration.md
+++ b/runtime/fundamentals/configuration.md
@@ -130,13 +130,12 @@ import map's URL or file path.
 
 ### Overriding packages
 
-The `patch` field in `deno.json` allows you to override dependencies without
-modifying their source code. It also allows you to use packages stored locally
-on disk.
+The `links` field in `deno.json` allows you to override dependencies with local
+packages stored on disk. This is similar to `npm link`.
 
 ```json title="deno.json"
 {
-  "patch": [
+  "links": [
     "../some-package"
   ]
 }
@@ -147,7 +146,6 @@ This capability addresses several common development challenges:
 - Dependency bug fixes
 - Private local libraries
 - Compatibility issues
-- Security concerns
 
 The package being referenced doesn't need to be published at all. It just needs
 to have the proper package name and metadata in `deno.json` or `package.json`,


### PR DESCRIPTION
With Deno 2.3.6, the `patch` field has been renamed to `links`. This PR updates the docs.

- https://github.com/denoland/deno/pull/29677

P.S. I would be grateful if the PR that makes `links` work with Vite get reviewed too.

- https://github.com/denoland/deno-vite-plugin/pull/69