### PR TITLE
fix: change fundamentals/modules 'Import Maps Standard' link

### DIFF
--- a/runtime/fundamentals/modules.md
+++ b/runtime/fundamentals/modules.md
@@ -144,7 +144,7 @@ when importing them in multiple files. You can centralize management of remote
 modules with an `imports` field in your `deno.json` file. We call this `imports`
 field the **import map**, which is based on the [Import Maps Standard].
 
-[Import Maps Standard]: https://github.com/WICG/import-maps
+[Import Maps Standard]: https://html.spec.whatwg.org/multipage/webappapis.html#import-maps
 
 ```json title="deno.json"
 {


### PR DESCRIPTION
Hey, noticed this while reading the docs, the github repo mentioned has been deprecated and the standard is now a part of the HTML standard, changed the url to that.