### PR TITLE
Update docker.md

### DIFF
--- a/runtime/reference/docker.md
+++ b/runtime/reference/docker.md
@@ -34,7 +34,7 @@ For smaller production images:
 
 ```dockerfile
 # Build stage
-FROM denoland/deno:latest as builder
+FROM denoland/deno:latest AS builder
 WORKDIR /app
 COPY . .
 RUN deno cache main.ts


### PR DESCRIPTION
Fixes Docker warning when building: 

```
1 warning found (use docker --debug to expand):  
  - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)
```