### PR TITLE
fix(minor): remove typo in Express example

### DIFF
--- a/examples/tutorials/express.md
+++ b/examples/tutorials/express.md
@@ -73,21 +73,23 @@ When you initialized the project, Deno set up a task which will run the main.ts
 file, you can see it in the `deno.json` file. Update the `dev` task to include
 the [`--allow-net`](/runtime/fundamentals/security/#network-access) flag:
 
-````jsonc
+```jsonc
 {
   "scripts": {
     "dev": "deno run --allow-net main.ts"
   }, 
   ...
 }
+```
 
-This will allow the project to make network requests. You can [read more about permissions flags](/runtime/fundamentals/security/).
+This will allow the project to make network requests. You can
+[read more about permissions flags](/runtime/fundamentals/security/).
 
 Now you can run the server with:
 
 ```sh
 deno run dev
-````
+```
 
 If you visit `localhost:8000` in your browser, you should see:
 


### PR DESCRIPTION
| Before | After |
| :--: | :--: |
| <img width="674" height="614" alt="Screenshot 2025-07-14 at 19 07 59" src="https://github.com/user-attachments/assets/7a3d5892-b65a-4917-a9ac-a8c7168edd0a" /> | <img width="634" height="707" alt="Screenshot 2025-07-14 at 19 08 26" src="https://github.com/user-attachments/assets/4f191823-6bc3-445f-91ca-fee2ca2de483" /> |
