### PR TITLE
fix package install name typo in React Tutorial

### DIFF
--- a/examples/tutorials/react.md
+++ b/examples/tutorials/react.md
@@ -59,14 +59,14 @@ configure both vite and Deno to work together.
 Install the deno plugin for Vite, the React types and the Vite React plugin:
 
 ```sh
-deno add npm:deno-vite-plugin@latest npm:@types/react@latest npm:@vitejs/plugin-react@latest
+deno add npm:@deno/vite-plugin@latest npm:@types/react@latest npm:@vitejs/plugin-react@latest
 ```
 
 We'll also need to install the Oak web framework for Deno to handle our API
 requests, and CORS middleware to allow cross-origin requests from the React app:
 
 ```sh
-deno add jsr:@oak/oak@ jsr:@tajpouria/cors
+deno add jsr:@oak/oak jsr:@tajpouria/cors
 ```
 
 This will add these dependencies to a new `deno.json` file.


### PR DESCRIPTION
This pull request updates the instructions in the `examples/tutorials/react.md` file to correct the installation commands for configuring Vite and Deno together. The changes ensure the correct package names and versions are used.

* **Dependency installation fixes:**
  * Updated the Vite plugin dependency from `npm:deno-vite-plugin` to `npm:@deno/vite-plugin` to reflect the correct package name.
  * Removed unnecessary version placeholders (`@`) from the Oak dependency in the `deno add` command.