### PR TITLE
fix: update EA limitations

### DIFF
--- a/deploy/early-access/reference/apps.md
+++ b/deploy/early-access/reference/apps.md
@@ -43,10 +43,6 @@ documentation.
 
 ## Limitations
 
-> ⚠️ Apps cannot currently be deleted.
-
-> ⚠️ Apps cannot currently be renamed.
-
 > ⚠️ Apps cannot currently be transferred to another organization.
 
 ## GitHub integration


### PR DESCRIPTION
Apps on EA can be both renamed and deleted now.