### PR TITLE
Shuffle head links to reduce CLS

### DIFF
--- a/_components/Logo.tsx
+++ b/_components/Logo.tsx
@@ -7,7 +7,7 @@ export default function Logo() {
       version="1.1"
       xmlns="http://www.w3.org/2000/svg"
       xmlSpace="preserve"
-      style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+      style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;max-width:12rem;"
     >
       <g
         id="background"

--- a/_includes/layout.tsx
+++ b/_includes/layout.tsx
@@ -18,6 +18,24 @@ export default function Layout(data: Lume.Data) {
         <title>{deleteBackticks(data.title)}</title>
         <link rel="icon" href="/favicon.ico" />
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+            (function() {
+              const theme = localStorage.getItem('denoDocsTheme') ||
+              (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+              document.documentElement.classList.add(theme);
+            })();
+            `,
+          }}
+        >
+        </script>
+
+        <link rel="stylesheet" href="/gfm.css" />
+        <link rel="stylesheet" href="/styles.css" />
+        <link rel="stylesheet" href="/components.css" />
+        <link rel="stylesheet" href="/overrides.css" />
+        <link rel="stylesheet" href="/style.css" />
         <link
           rel="preload"
           href="/fonts/inter/Inter-Regular.woff2"
@@ -43,24 +61,6 @@ export default function Layout(data: Lume.Data) {
           name="keywords"
           content="Deno, JavaScript, TypeScript, reference, documentation, guide, tutorial, example"
         />
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `
-            (function() {
-              const theme = localStorage.getItem('denoDocsTheme') ||
-                (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-              document.documentElement.classList.add(theme);
-            })();
-          `,
-          }}
-        >
-        </script>
-
-        <link rel="stylesheet" href="/gfm.css" />
-        <link rel="stylesheet" href="/styles.css" />
-        <link rel="stylesheet" href="/overrides.css" />
-        <link rel="stylesheet" href="/style.css" />
-        <link rel="stylesheet" href="/components.css" />
         <script type="module" defer src="/components.js"></script>
         <script type="module" defer src="/lint_rules.client.js"></script>
         <script type="module" defer src="/copy.client.js"></script>

--- a/_includes/layout.tsx
+++ b/_includes/layout.tsx
@@ -18,17 +18,10 @@ export default function Layout(data: Lume.Data) {
         <title>{deleteBackticks(data.title)}</title>
         <link rel="icon" href="/favicon.ico" />
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `
-            (function() {
-              const theme = localStorage.getItem('denoDocsTheme') ||
-              (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-              document.documentElement.classList.add(theme);
-            })();
-            `,
-          }}
-        >
+        <script>
+          const theme = localStorage.getItem('denoDocsTheme') ||
+          (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' :
+          'light'); document.documentElement.classList.add(theme);
         </script>
 
         <link rel="stylesheet" href="/gfm.css" />


### PR DESCRIPTION
Closes https://github.com/denoland/docs/issues/1912

Looks like there are a lot of reasons for the weird blip of loading unstyled content, including network, caching, (I think) Firefox itself, and loading so much CSS from so many different sources. But this reordering of the items in the `<head>` seems to help, at least.