### PR TITLE
fix typo on fmt json

### DIFF
--- a/examples/videos/deno_fmt.md
+++ b/examples/videos/deno_fmt.md
@@ -186,7 +186,7 @@ Note that all these options also have a corresponding flags in the CLI.
     "useTabs": true,
     "lineWidth": 80,
     "indentWidth": 2,
-    "semiColon": false,
+    "semiColons": false,
     "singleQuote": true,
     "proseWrap": "always",
     "exclude": ["**/logs.json"]


### PR DESCRIPTION
There's a typo in the documentation of the fmt, when copying and pasting this text, it fails because it's semiColons with an 's' at the end.