### PR TITLE
Responsive fixes

### DIFF
--- a/_components/Hamburger.tsx
+++ b/_components/Hamburger.tsx
@@ -1,6 +1,6 @@
 export default function () {
   const commonClasses =
-    `block w-6 h-[2px] bg-foreground-primary duration-200 ease-[cubic-bezier(0.77,0,0.175,1)]`;
+    `block w-6 h-0.5 bg-foreground-primary duration-200 ease-[cubic-bezier(0.77,0,0.175,1)]`;
   return (
     <>
       <button

--- a/_components/Header.tsx
+++ b/_components/Header.tsx
@@ -41,12 +41,15 @@ export default function (
                 hrefIsInCurrentSection(nav.href, currentSection)
                   ? "font-bold text-gray-800 bg-header-highlight"
                   : ""
+              } ${
+                nav.href === "/services/"
+                  ? "before:h-[calc(100%-3rem)] before:absolute before:w-px before:bg-foreground-secondary before:top-4 before:left-0"
+                  : ""
               } ${nav.style ?? ""}`}
               {...(hrefIsInCurrentSection(nav.href, currentSection)
                 ? { "data-active": true, "aria-current": "location" }
                 : {})}
             >
-              {}
               {hrefIsInCurrentSection(nav.href, currentSection) && (
                 <div
                   id="current-nav-item"

--- a/_components/Header.tsx
+++ b/_components/Header.tsx
@@ -41,10 +41,6 @@ export default function (
                 hrefIsInCurrentSection(nav.href, currentSection)
                   ? "font-bold text-gray-800 bg-header-highlight"
                   : ""
-              } ${
-                nav.href === "/services/"
-                  ? "before:h-[calc(100%-3rem)] before:absolute before:w-px before:bg-foreground-secondary before:top-4 before:left-0"
-                  : ""
               } ${nav.style ?? ""}`}
               {...(hrefIsInCurrentSection(nav.href, currentSection)
                 ? { "data-active": true, "aria-current": "location" }

--- a/_components/TableOfContentsMobile.tsx
+++ b/_components/TableOfContentsMobile.tsx
@@ -14,7 +14,7 @@ export default function TableOfContents({ data, toc }: {
         On this page
       </summary>
 
-      <ul className="p-4 pt-2 text-foreground-primary">
+      <ul className="p-4 pt-2">
         {toc.map((item: TableOfContentsItem_) => (
           <data.comp.TableOfContentsItem item={item} />
         ))}

--- a/styles.css
+++ b/styles.css
@@ -287,7 +287,7 @@ h1 {
 
 .markdown-body {
   color: hsl(var(--foreground-primary));
-  font-family: inherit;
+  font: inherit;
   @apply bg-transparent !important;
 
   /* Override gfm base styles */
@@ -410,9 +410,10 @@ pre.highlight:has(code):where(:hover, :focus) + .copyButton {
 }
 
 .markdownBlockTitle {
-  @apply bg-slate-100 px-2 py-1 leading-none rounded border text-xs
-    font-semibold z-10 relative w-max !-mb-4 text-foreground-secondary/80
-    sm:left-2 -top-1 dark:border-background-tertiary dark:bg-slate-900;
+  background: var(--bgColor-muted, var(--color-canvas-subtle));
+  @apply px-2 py-1 leading-none rounded border text-xs font-semibold z-10
+    relative w-max !-mb-4 text-foreground-primary sm:left-2 -top-1
+    border-foreground-tertiary;
 }
 
 .deno-tabs .markdownBlockTitle {
@@ -941,13 +942,13 @@ body:has(.raw-container)
 
   #hamburger-button[aria-pressed="true"] {
     .hamburger-bar--top {
-      transform: translate(0, 7px) rotate(45deg);
+      transform: translate(0, 0.4375rem) rotate(45deg);
     }
     .hamburger-bar--middle {
       opacity: 0;
     }
     .hamburger-bar--bottom {
-      transform: translate(0, -7px) rotate(-45deg);
+      transform: translate(0, -0.4375rem) rotate(-45deg);
     }
   }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,7 +22,12 @@ export default {
     extend: {
       screens: {
         "xs": "30rem",
+        "sm": "40rem",
+        "md": "48rem",
+        "lg": "64rem",
+        "xl": "80rem",
         "xlplus": "82rem",
+        "2xl": "96rem",
       },
       colors: {
         transparent: "transparent",


### PR DESCRIPTION
Mainly changes breakpoints from `px` units to `rem` units, so that responsive sizing scales with the user's font preference, not just the screen size. Also makes some other minor adjustments for better responsiveness, such as forcing `.markdown-body` to inherit font size, rather than set it at an inflexible `16px`.