### PR TITLE
fix: use error code 426 upgrade required in websocket docs

### DIFF
--- a/examples/scripts/http_server_websocket.ts
+++ b/examples/scripts/http_server_websocket.ts
@@ -13,10 +13,10 @@
 // To start the server on the default port, call `Deno.serve` with the handler.
 Deno.serve((req) => {
   // First, we verify if the client is negotiating to upgrade to websockets.
-  // If not, we can give a status of 501 to specify we don't support plain
+  // If not, we can give a status of 426 to specify we don't support plain
   // http requests.
   if (req.headers.get("upgrade") != "websocket") {
-    return new Response(null, { status: 501 });
+    return new Response(null, { status: 426 });
   }
 
   // We can then upgrade the request to a websocket

--- a/runtime/fundamentals/http_server.md
+++ b/runtime/fundamentals/http_server.md
@@ -250,7 +250,7 @@ Documentation for it can be found
 ```ts title="server.ts"
 Deno.serve((req) => {
   if (req.headers.get("upgrade") != "websocket") {
-    return new Response(null, { status: 501 });
+    return new Response(null, { status: 426 });
   }
 
   const { socket, response } = Deno.upgradeWebSocket(req);


### PR DESCRIPTION
426 is the proper error code for servers that expect websocket connections and do not recieve such

https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/426