### PR TITLE
Symmetrical sidebars

### DIFF
--- a/_components/Navigation.tsx
+++ b/_components/Navigation.tsx
@@ -15,7 +15,7 @@ export default function (
   return (
     <>
       <aside
-        className={`fixed transition-all duration-200 md:duration-0 easing-[cubic-bezier(0.165,0.84,0.44,1)] -translate-x-full z-50 w-full bg-background-raw opacity-0 p-4 pb-8 overflow-auto text-[0.8125rem] md:sticky md:overflow-y-auto md:[scrollbar-width:thin] md:z-10 md:!translate-x-0 md:!opacity-100 md:p-0 md:pb-16 sidebar-open:translate-x-0 sidebar-open:opacity-100
+        className={`fixed transition-all duration-200 md:duration-0 easing-[cubic-bezier(0.165,0.84,0.44,1)] -translate-x-full z-50 w-full bg-background-raw opacity-0 p-4 pb-8 overflow-auto text-[0.8125rem] md:sticky md:overflow-y-auto md:[scrollbar-width:thin] md:z-10 md:!translate-x-0 md:!opacity-100 md:p-0 md:pb-16 lg:border-r lg:border-r-foreground-tertiary lg:w-full sidebar-open:translate-x-0 sidebar-open:opacity-100
          ${
           hasSubNav
             ? "top-header-plus-subnav h-screen-minus-both"
@@ -24,6 +24,7 @@ export default function (
         data-component="sidebar-nav"
         data-section={currentSection}
         id="nav"
+        style="scrollbar-width: none;"
         tabIndex={-1}
       >
         <data.comp.SidebarNav

--- a/_components/TableOfContents.tsx
+++ b/_components/TableOfContents.tsx
@@ -12,7 +12,7 @@ export default function TableOfContents({ data, toc, hasSubNav }: {
 
   return (
     <ul
-      className={`toc-list hidden sticky p-4 pr-0 min-w-40 h-screen-minus-header overflow-y-auto border-l border-l-foreground-tertiary lg:block ${topClasses}`}
+      className={`toc-list hidden sticky p-4 pr-0 h-screen-minus-header overflow-y-auto border-l border-l-foreground-tertiary lg:block lg:w-full ${topClasses}`}
       id="toc"
     >
       {toc.map((item: TableOfContentsItem_) => (

--- a/_components/TableOfContentsItem.tsx
+++ b/_components/TableOfContentsItem.tsx
@@ -4,7 +4,7 @@ export default function TableOfContentsItem(
   props: { item: TableOfContentsItem_ },
 ) {
   return (
-    <li class="m-2 mr-0 leading-4">
+    <li class="m-2 mr-0 leading-4 text-balance">
       <a
         href={`#${props.item.slug}`}
         className="text-[0.8125rem] lg:text-foreground-secondary hover:text-primary transition-colors duration-200 ease-in-out select-none"

--- a/_includes/layout.tsx
+++ b/_includes/layout.tsx
@@ -86,7 +86,7 @@ export default function Layout(data: Lume.Data) {
         />
         <div
           class={`layout ${
-            data.toc ? "layout--three-column" : "layout--two-column"
+            data.toc?.length ? "layout--three-column" : "layout--two-column"
           }`}
         >
           <data.comp.Navigation

--- a/reference/_components/DocEntry.tsx
+++ b/reference/_components/DocEntry.tsx
@@ -23,7 +23,10 @@ export default function (
             )
             : (
               docEntry.name && (
-                <span className="font-bold font-lg">{docEntry.name}</span>
+                <span
+                  className="font-bold font-lg"
+                  dangerouslySetInnerHTML={{ __html: docEntry.name }}
+                />
               )
             )}
           {/*typedef rendering*/}

--- a/static/reference_styles.css
+++ b/static/reference_styles.css
@@ -1,132 +1,3 @@
-.ddoc .static {
-  position: static;
-}
-.ddoc .relative {
-  position: relative;
-}
-.ddoc .\!mb-0 {
-  margin-bottom: 0 !important;
-}
-.ddoc .\!mt-2 {
-  margin-top: 0.5rem !important;
-}
-.ddoc .mb-1 {
-  margin-bottom: 0.25rem;
-}
-.ddoc .ml-4 {
-  margin-left: 1rem;
-}
-.ddoc .ml-indent {
-  display: inline;
-  margin: 0;
-}
-.ddoc .mr-2 {
-  margin-right: 0.5rem;
-}
-.ddoc .mt-3 {
-  margin-top: 0.75rem;
-}
-.ddoc .inline {
-  display: inline;
-}
-.ddoc .\!flex {
-  display: flex !important;
-}
-.ddoc .flex {
-  display: flex;
-}
-.ddoc .inline-flex {
-  display: inline-flex;
-}
-.ddoc .table {
-  display: table;
-}
-.ddoc .contents {
-  display: contents;
-}
-.ddoc .hidden {
-  display: none;
-}
-.ddoc .h-4 {
-  height: 1rem;
-}
-.ddoc .h-5 {
-  height: 1.25rem;
-}
-.ddoc .min-w-0 {
-  min-width: 0;
-}
-.ddoc .max-w-\[75ch\] {
-  max-width: 75ch;
-}
-.ddoc .flex-1 {
-  flex: 1;
-}
-.ddoc .flex-none {
-  flex: none;
-}
-.ddoc .rotate-90 {
-  --tw-rotate: 90deg;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y))
-    rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
-    scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-.ddoc .scroll-mt-16 {
-  scroll-margin-top: 4rem;
-}
-.ddoc .items-center {
-  align-items: center;
-}
-.ddoc .gap-0 {
-  gap: 0;
-}
-.ddoc .gap-0\.5 {
-  gap: 0.125rem;
-}
-.ddoc .gap-1 {
-  gap: 0.25rem;
-}
-.ddoc .space-x-1 > :not([hidden]) ~ :not([hidden]) {
-  --tw-space-x-reverse: 0;
-  margin-right: calc(0.25rem * var(--tw-space-x-reverse));
-  margin-left: calc(0.25rem * calc(1 - var(--tw-space-x-reverse)));
-}
-.ddoc .space-x-2 > :not([hidden]) ~ :not([hidden]) {
-  --tw-space-x-reverse: 0;
-  margin-right: calc(0.5rem * var(--tw-space-x-reverse));
-  margin-left: calc(0.5rem * calc(1 - var(--tw-space-x-reverse)));
-}
-.ddoc .space-y-2 > :not([hidden]) ~ :not([hidden]) {
-  --tw-space-y-reverse: 0;
-  margin-top: calc(0.5rem * calc(1 - var(--tw-space-y-reverse)));
-  margin-bottom: calc(0.5rem * var(--tw-space-y-reverse));
-}
-.ddoc .space-y-8 > :not([hidden]) ~ :not([hidden]) {
-  --tw-space-y-reverse: 0;
-  margin-top: calc(2rem * calc(1 - var(--tw-space-y-reverse)));
-  margin-bottom: calc(2rem * var(--tw-space-y-reverse));
-}
-.ddoc .break-words {
-  overflow-wrap: break-word;
-}
-.ddoc .break-all {
-  word-break: break-all;
-}
-.ddoc .rounded {
-  border-radius: 0.25rem;
-}
-.ddoc .rounded-md {
-  border-radius: 0.375rem;
-}
-.ddoc .border {
-  border-width: 1px;
-}
-.ddoc .border-b {
-  border-bottom-width: 1px;
-}
-.ddoc .border-l-2 {
-  border-left-width: 2px;
-}
 .ddoc .border-Class\/50 {
   border-color: #20b44b80;
 }
@@ -160,10 +31,6 @@
 .ddoc .border-deprecated\/50 {
   border-color: #dc262680;
 }
-.ddoc .border-gray-300 {
-  --tw-border-opacity: 1;
-  border-color: rgb(209 213 219 / var(--tw-border-opacity));
-}
 .ddoc .border-new\/50 {
   border-color: #7b61ff80;
 }
@@ -180,10 +47,6 @@
 .ddoc .border-protected\/50,
 .ddoc .border-readonly\/50 {
   border-color: #7b61ff80;
-}
-.ddoc .border-stone-300 {
-  --tw-border-opacity: 1;
-  border-color: rgb(214 211 209 / var(--tw-border-opacity));
 }
 .ddoc .border-unstable\/50,
 .ddoc .border-writeonly\/50 {
@@ -313,55 +176,6 @@
 .ddoc .bg-writeonly\/5 {
   background-color: #7b61ff0d;
 }
-.ddoc .px-2 {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
-}
-.ddoc .px-3 {
-  padding-left: 0.75rem;
-  padding-right: 0.75rem;
-}
-.ddoc .px-4 {
-  padding-left: 1rem;
-  padding-right: 1rem;
-}
-.ddoc .py-1 {
-  padding-top: 0.25rem;
-  padding-bottom: 0.25rem;
-}
-.ddoc .py-2 {
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-}
-.ddoc .pb-5 {
-  padding-bottom: 1.25rem;
-}
-.ddoc .pt-4 {
-  padding-top: 1rem;
-}
-.ddoc .text-2xl {
-  font-size: 1.5rem;
-  line-height: 2rem;
-}
-.ddoc .text-sm {
-  font-size: 0.875rem;
-  line-height: 1.25rem;
-}
-.ddoc .font-bold {
-  font-weight: 700;
-}
-.ddoc .font-medium {
-  font-weight: 500;
-}
-.ddoc .font-normal {
-  font-weight: 400;
-}
-.ddoc .italic {
-  font-style: italic;
-}
-.ddoc .leading-none {
-  line-height: 1;
-}
 .ddoc .text-Class {
   --tw-text-opacity: 1;
   color: rgb(32 180 75 / var(--tw-text-opacity));
@@ -427,10 +241,6 @@
 .ddoc .text-readonly {
   --tw-text-opacity: 1;
   color: rgb(123 97 255 / var(--tw-text-opacity));
-}
-.ddoc .text-stone-500 {
-  --tw-text-opacity: 1;
-  color: rgb(120 113 108 / var(--tw-text-opacity));
 }
 .ddoc .text-unstable,
 .ddoc .text-writeonly {
@@ -969,22 +779,14 @@ ul.namespaceItemContentSubItems {
   gap: 0.25rem;
   display: inline-flex;
   z-index: 1;
-}
-.ddoc .breadcrumbs > li:first-child {
-  font-size: 1.5rem;
-  font-weight: 700;
+  font-size: 0.875rem;
   line-height: 1;
 }
-.ddoc .breadcrumbs li {
-  font-size: 1.125rem;
-  line-height: 0.9em;
-  display: inline;
+.ddoc .breadcrumbs > li:first-child {
+  font-weight: 700;
 }
-@media (min-width: 64rem) {
-  .ddoc .breadcrumbs li {
-    font-size: 1.25rem;
-    line-height: 1.75rem;
-  }
+.ddoc .breadcrumbs li {
+  display: inline;
 }
 .ddoc .context_button {
   z-index: 10;
@@ -1005,18 +807,6 @@ ul.namespaceItemContentSubItems {
 }
 .ddoc .see > li * {
   display: inline-block;
-}
-.ddoc .\*\:h-4 > * {
-  height: 1rem;
-}
-.ddoc .\*\:h-5 > * {
-  height: 1.25rem;
-}
-.ddoc .\*\:w-auto > * {
-  width: auto;
-}
-.ddoc .\*\:flex-none > * {
-  flex: none;
 }
 .ddoc .hover\:bg-Class\/15:hover {
   background-color: #20b44b26;

--- a/styles.css
+++ b/styles.css
@@ -381,12 +381,12 @@ h1 {
 pre:has(code.highlight),
 pre.highlight:has(code) {
   @apply px-4 py-8 -mx-4 sm:mx-0 border-x-0 sm:border sm:px-8 rounded-none
-    sm:rounded-md border-foreground-tertiary;
+    sm:rounded-md border-background-tertiary;
   overflow-x: auto;
 }
 
-pre:has(code.highlight):where(:hover, :focus) + .copyButton,
-pre.highlight:has(code):where(:hover, :focus) + .copyButton {
+pre:where(:hover, :focus) + .copyButton,
+pre.highlight:where(:hover, :focus) + .copyButton {
   @apply opacity-100;
 }
 
@@ -1068,7 +1068,7 @@ body:has(.raw-container)
       background: hsl(var(--foreground-primary));
       clip-path: polygon(0 0, 100% 50%, 0 100%);
       position: absolute;
-      left: -1rem;
+      left: -1em;
       top: calc(50% - 0.25em);
     }
   }

--- a/styles.css
+++ b/styles.css
@@ -686,15 +686,6 @@ pre.highlight:has(code):where(:hover, :focus) + .copyButton {
   }
 }
 
-#toc {
-  scrollbar-width: thin;
-}
-
-#nav,
-#toc {
-  max-width: 15rem;
-}
-
 .copyButton[data-copied="true"] .copy-icon {
   display: none;
 }
@@ -868,6 +859,16 @@ main:has(#example:checked) {
 
   .layout--three-column {
     grid-template-columns: auto minmax(0, 1fr) auto;
+
+    @media (min-width: 64rem) {
+      grid-template-columns:
+        minmax(12rem, 1fr) minmax(24rem, 3fr) minmax(12rem, 1fr);
+    }
+
+    @media (min-width: 80rem) {
+      grid-template-columns:
+        minmax(12rem, 2fr) minmax(30rem, 5fr) minmax(12rem, 2fr);
+    }
 
     .content {
       margin-right: -1rem;

--- a/styles.css
+++ b/styles.css
@@ -876,7 +876,7 @@ main:has(#example:checked) {
   }
 
   .layout--two-column {
-    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-columns: minmax(12rem, 1fr) minmax(24rem, 3fr);
   }
 
   .layout:has(.raw-container) {


### PR DESCRIPTION
### Main changes:

-  Makes the right and left sidebar symmetrical, in terms of width. Might look a little odd on some pages with very short ToC content, but I think it's an overall improvement, particularly above XL breakpoint. It also means navigating between docs pages is a little smoother, since the layout is always the same.
- Removes the scrollbar from the left sidebar. I did this because it looks better, and because I feel it's probably very intuitive that the left sidebar is scrollable (it's virtually always overflowing, and is common convention anyway), but this specific change I could be persuaded both ways. I know scrollbars should generally be visible always, but here I think there's very little reason for concern. (If we keep this: do we also do the same for the right sidebar?)

### Minor updates:
- Fixes some hide/show logic for the ToC (right sidebar)
- Nudges the progress indicator closer to the text
- Adds text balancing to right sidebar items, so long text wraps evenly
- Removes several now-unnecessary Tailwind classes from the ddoc CSS
- Removes some unneeded `:has()` from CSS
- Shrinks reference breadcrumbs for better consistency with other pages and better visual hierarchy
- Makes the border around `<pre>` elements slightly more subtle
- Fixes an issue in the reference gen where HTML elements sometimes show in the content (image below)

<img width="413" height="115" alt="image" src="https://github.com/user-attachments/assets/bab62ab0-6a09-4b5c-b6ba-d835db20d6d4" />
