### PR TITLE
remove section titles from the breadcrumbs

### DIFF
--- a/_components/Breadcrumbs.tsx
+++ b/_components/Breadcrumbs.tsx
@@ -1,126 +1,143 @@
 import type { Sidebar as Sidebar_, SidebarItem } from "../types.ts";
 
-function generateCrumbs(
+function buildBreadcrumbPath(
   url: string,
   title: string,
   items: SidebarItem[],
-  current: SidebarItem[] = [],
-): SidebarItem[] {
+  breadcrumbPath: SidebarItem[] = [],
+): SidebarItem[] | null {
   for (const item of items) {
-    const foundTargetPage = item.href === url;
-
-    if (foundTargetPage) {
-      current.push({ title: title });
-      return current;
+    // Check if this is the target page
+    if (item.href === url) {
+      return [...breadcrumbPath, { title }];
     }
 
-    if (item.items) {
-      const childItems: SidebarItem[] = [];
-      generateCrumbs(url, title, item.items, childItems);
+    // If item has children, search recursively
+    if (item.items && item.items.length > 0) {
+      const childPath = buildBreadcrumbPath(
+        url,
+        title,
+        item.items,
+        [...breadcrumbPath, { title: item.title, href: item.href }],
+      );
 
-      if (childItems.length > 0) {
-        if (item.href) {
-          current.push({ title: item.title, href: item.href });
-        }
-        current.push(...childItems);
-        return current;
+      if (childPath) {
+        return childPath;
       }
     }
   }
 
-  return current;
+  return null;
 }
 
-export default function (props: {
+export default function Breadcrumbs(props: {
   title: string;
   sidebar: Sidebar_;
   url: string;
-  sectionTitle: string;
-  sectionHref: string;
-}, helpers: Lume.Helpers) {
-  const crumbs: SidebarItem[] = [];
+}) {
+  let breadcrumbs: SidebarItem[] = [];
 
+  // Extract the top-level section from the URL (e.g., "runtime", "deploy")
+  const topLevelSection = props.url.split("/").filter(Boolean)[0];
+
+  // Define section name mappings for better display
+  const sectionNames: Record<string, string> = {
+    "runtime": "Runtime",
+    "services": "Services",
+    "deploy": "Deploy",
+    "subhosting": "Subhosting",
+    "examples": "Examples",
+    "lint": "Lint",
+    "api": "API Reference",
+  };
+
+  // Search through all sidebar sections to find the breadcrumb path
   for (const section of props.sidebar) {
+    // Check if the current URL is a top-level section
     if (section.href === props.url) {
-      crumbs.push({ title: props.title });
+      // If this page IS the section, just show the page title
+      breadcrumbs = [{ title: props.title }];
       break;
     }
 
-    const rootItem = { title: section.title, href: section.href };
-    const potentialCrumbs = generateCrumbs(
-      props.url,
-      props.title,
-      section?.items || [],
-      [rootItem],
-    );
+    // Search within section items if they exist
+    if (section.items) {
+      const foundPath = buildBreadcrumbPath(
+        props.url,
+        props.title,
+        section.items,
+        [], // Start with empty path, we'll add section as base
+      );
 
-    if (potentialCrumbs.length > 1) {
-      crumbs.push(...potentialCrumbs);
-      break;
+      if (foundPath) {
+        // Add the top-level section as the base breadcrumb
+        const sectionDisplayName = sectionNames[topLevelSection] ||
+          (topLevelSection?.charAt(0).toUpperCase() +
+            topLevelSection?.slice(1)) ||
+          "Docs";
+
+        breadcrumbs = [
+          { title: sectionDisplayName, href: `/${topLevelSection}/` },
+          ...foundPath,
+        ];
+        break;
+      }
     }
   }
 
+  // If no breadcrumbs found, just show the current page title
+  if (breadcrumbs.length === 0) {
+    breadcrumbs = [{ title: props.title }];
+  }
+
   const linkClasses =
-    `flex items-center pl-3 py-1.5 underline underline-offset-4 decoration-foreground-tertiary hover:text-foreground-secondary hover:underline-medium hover:bg-foreground-quaternary dark:hover:bg-background-secondary dark:hover:text-foreground-primary rounded transition duration-100 text-xs`;
+    "flex items-center pl-3 py-1.5 underline underline-offset-4 decoration-foreground-tertiary hover:text-foreground-secondary hover:underline-medium hover:bg-foreground-quaternary dark:hover:bg-background-secondary dark:hover:text-foreground-primary rounded transition duration-100 text-xs";
 
   const chevronClasses =
-    `after:w-4 after:h-4 after:[background:url(./img/chevron.svg)_no-repeat_center] after:inline-block after:ml-2`;
+    "after:w-4 after:h-4 after:[background:url(./img/chevron.svg)_no-repeat_center] after:inline-block after:ml-2";
 
   return (
     <nav>
       <ul
-        class="flex flex- items-center text-center mt-2 -ml-3 text-foreground-secondary sm:mt-4"
+        class="flex items-center text-center mt-2 -ml-3 text-foreground-secondary sm:mt-4"
         itemscope
         itemtype="https://schema.org/BreadcrumbList"
       >
-        <li
-          itemprop="itemListElement"
-          itemscope
-          itemtype="https://schema.org/ListItem"
-        >
-          <a
-            class={`${linkClasses} ${chevronClasses}`}
-            itemprop="item"
-            href={props.sectionHref}
+        {breadcrumbs.map((crumb, i) => (
+          <li
+            key={i}
+            itemprop="itemListElement"
+            itemscope
+            itemtype="https://schema.org/ListItem"
           >
-            <span
-              itemprop="name"
-              dangerouslySetInnerHTML={{ __html: props.sectionTitle }}
-            />
-          </a>
-          <meta itemprop="position" content="1" />
-        </li>
-        {crumbs.map((crumb, i) => (
-          <>
-            <li
-              itemprop="itemListElement"
-              itemscope
-              itemtype="https://schema.org/ListItem"
-            >
-              {crumb.href
-                ? (
-                  <a
-                    href={crumb.href}
-                    itemprop="item"
-                    class={`${linkClasses} ${chevronClasses}`}
-                  >
-                    <span itemprop="name">{crumb.title}</span>
-                  </a>
-                )
-                : (
-                  <span
-                    itemprop="name"
-                    class={`flex items-center pl-2 py-1.5 text-xs ${
-                      i < crumbs.length - 1 ? chevronClasses : ""
-                    }`}
-                    dangerouslySetInnerHTML={{
-                      __html: helpers.md(crumb.title, true),
-                    }}
-                  />
-                )}
-              <meta itemprop="position" content={String(i + 2)} />
-            </li>
-          </>
+            {crumb.href
+              ? (
+                <a
+                  href={crumb.href}
+                  itemprop="item"
+                  class={`${linkClasses} ${
+                    i < breadcrumbs.length - 1 ? chevronClasses : ""
+                  }`}
+                >
+                  <span itemprop="name">
+                    {typeof crumb.title === "string"
+                      ? crumb.title
+                      : crumb.title}
+                  </span>
+                </a>
+              )
+              : (
+                <span
+                  itemprop="name"
+                  class={`flex items-center pl-2 py-1.5 text-xs ${
+                    i < breadcrumbs.length - 1 ? chevronClasses : ""
+                  }`}
+                >
+                  {typeof crumb.title === "string" ? crumb.title : crumb.title}
+                </span>
+              )}
+            <meta itemprop="position" content={String(i + 1)} />
+          </li>
         ))}
       </ul>
     </nav>

--- a/_includes/doc.tsx
+++ b/_includes/doc.tsx
@@ -41,8 +41,6 @@ export default function Doc(data: Lume.Data, helpers: Lume.Helpers) {
               title={data.title!}
               sidebar={sidebar}
               url={data.url}
-              sectionTitle={data.sectionTitle!}
-              sectionHref={data.sectionHref!}
             />
           )}
 


### PR DESCRIPTION
Old: 
<img width="1094" height="437" alt="image" src="https://github.com/user-attachments/assets/4f2e4917-abff-42f6-8f4c-3fe3eb6ed9a8" />


New: 
<img width="1109" height="517" alt="image" src="https://github.com/user-attachments/assets/1b0d3189-2bf8-4ed4-ad49-206540a19f7c" />

Closes #2417