### PR TITLE
make the first column of the two col layout the same width as the fir…

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -866,6 +866,17 @@ main:has(#example:checked) {
 
   .layout--two-column {
     grid-template-columns: minmax(12rem, 1fr) minmax(24rem, 3fr);
+
+    @media (min-width: 64rem) {
+      grid-template-columns:
+        minmax(12rem, 1fr) minmax(24rem, 3fr) minmax(12rem, 1fr);
+    }
+
+    .content {
+      @media (min-width: 64rem) {
+        grid-column: 2 / 4;
+      }
+    }
   }
 
   .layout:has(.raw-container) {


### PR DESCRIPTION
make the first column of the two col layout the same width as the first column in the three column layout

old: 
<img width="1270" height="979" alt="image" src="https://github.com/user-attachments/assets/4fd17c81-c244-4363-8407-e92b1e5b0c68" />


new: 
<img width="1084" height="891" alt="image" src="https://github.com/user-attachments/assets/e255a61a-6c26-48e5-bf7a-5f1fbc0d09c0" />
