### PR TITLE
Add extensions.json

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "bradlc.vscode-tailwindcss",
+    "denoland.vscode-deno"
+  ]
+}


### PR DESCRIPTION
This lets anyone who opens the repo know what extensions we recommend for working with the docs site, with an option to install them all.