### PR TITLE
Fixed typo (examples/tutorials/fetch_data.md) - changed "bite" to "byte"

### DIFF
--- a/examples/tutorials/fetch_data.md
+++ b/examples/tutorials/fetch_data.md
@@ -70,7 +70,7 @@ We'll use the `fetch` API to retrieve a file. Then we'll use the
 the [`pipeTo`](/api/web/~/ReadableStream.pipeTo) method from the Streams API to
 send the byte stream to the created file.
 
-Next, we'll use the `readable` property on a `POST` request to send the bite
+Next, we'll use the `readable` property on a `POST` request to send the byte
 stream of the file to a server.
 
 ```ts title="stream.js"


### PR DESCRIPTION
I noticed "bite stream" was used instead of "byte stream", so I decided to open a PR to make the change :)