### PR TITLE
Update usage.md

### DIFF
--- a/deploy/early-access/usage.md
+++ b/deploy/early-access/usage.md
@@ -30,4 +30,4 @@ of the platform. However, the
 [Acceptable Use Policy](/deploy/manual/acceptable-use-policy/) and
 [Terms and Conditions](/deploy/manual/terms-and-conditions/) still apply, and we
 reserve the right to terminate any user, organization, or app that we find to be
-in violation of these terms. in violation of these.
+in violation of these terms.


### PR DESCRIPTION
Fix typo

Last paragraph originally read _While Deno DeployEA is in closed beta, we are not charging for usage of the platform. However, the [Acceptable Use Policy](https://docs.deno.com/deploy/manual/acceptable-use-policy/) and [Terms and Conditions](https://docs.deno.com/deploy/manual/terms-and-conditions/) still apply, and we reserve the right to terminate any user, organization, or app that we find to be in violation of these terms. **in violation of these.**_

The last _in violation of these._ seems to be a typo.