### PR TITLE
Fix: Corrected typo in unstable-component flag

### DIFF
--- a/runtime/fundamentals/linting_and_formatting.md
+++ b/runtime/fundamentals/linting_and_formatting.md
@@ -255,7 +255,7 @@ Define separator kind for type literals
 - **Default:** `semiColon`
 - **Possible values:** `comma`, `semiColon`
 
-#### unstable-component
+#### `unstable-component`
 
 Enable formatting Svelte, Vue, Astro and Angular files
 


### PR DESCRIPTION
The documentation for the `unstable-component` flag had a typo. This PR wraps the flag in backticks to match the formatting of other options like `unstable-sql` and `useTabs`.