### PR TITLE
docs(jsx): make example type-check

### DIFF
--- a/runtime/reference/jsx.md
+++ b/runtime/reference/jsx.md
@@ -61,10 +61,12 @@ To use the newer JSX runtime transform change the compiler options in your
 {
   "compilerOptions": {
     "jsx": "react-jsx",
-    "jsxImportSource": "react"
+    "jsxImportSource": "react",
+    "jsxImportSourceTypes": "@types/react"
   },
   "imports": {
-    "react": "npm:react"
+    "react": "npm:react",
+    "@types/react": "npm:@types/react"
   }
 }
 ```


### PR DESCRIPTION

<img width="777" height="344" alt="image" src="https://github.com/user-attachments/assets/80a4cd53-2753-4666-ab6a-bade664d0fc8" />

without [`jsxImportSourceTypes`](https://docs.deno.com/runtime/reference/jsx/#jsximportsourcetypes) deno (2.4.4) will error with:
```
JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
This JSX tag requires the module path 'react/jsx-runtime' to exist, but none could be found. Make sure you have types for the appropriate package installed.
```