### PR TITLE
fix: translate Portugal to English

### DIFF
--- a/examples/tutorials/prisma.md
+++ b/examples/tutorials/prisma.md
@@ -39,13 +39,13 @@ npx prisma@latest init --generator-provider prisma-client --output ./generated
 
 Let's understand the key parameters:
 
-- `--generator-provider prisma-client`: Define o provedor "prisma-client" ao
-  invés do padrão "prisma-client-js". O provedor "prisma-client" é otimizado
-  para Deno e gera código TypeScript compatível com o runtime do Deno.
+- `--generator-provider prisma-client`: Define the provides as
+  "prisma-client-js" instead of the default "prisma-client-js". The
+  "prisma-client" provider is optimized for Deno and generates TypeScript
+  code compatible with the Deno runtime.
 
-- `--output`: Define o diretório onde o Prisma salvará os arquivos do cliente
-  gerado, incluindo definições de tipos e utilitários de acesso ao banco de
-  dados.
+- `--output`: Defines the directory where Prisma will save the generated
+  client files, including type definitions and database access utilities.
 
 This will generate
 [`prisma/schema.prisma`](https://www.prisma.io/docs/orm/prisma-schema). Let's

--- a/examples/tutorials/prisma.md
+++ b/examples/tutorials/prisma.md
@@ -41,11 +41,11 @@ Let's understand the key parameters:
 
 - `--generator-provider prisma-client`: Define the provides as
   "prisma-client-js" instead of the default "prisma-client-js". The
-  "prisma-client" provider is optimized for Deno and generates TypeScript
-  code compatible with the Deno runtime.
+  "prisma-client" provider is optimized for Deno and generates TypeScript code
+  compatible with the Deno runtime.
 
-- `--output`: Defines the directory where Prisma will save the generated
-  client files, including type definitions and database access utilities.
+- `--output`: Defines the directory where Prisma will save the generated client
+  files, including type definitions and database access utilities.
 
 This will generate
 [`prisma/schema.prisma`](https://www.prisma.io/docs/orm/prisma-schema). Let's


### PR DESCRIPTION
Page https://docs.deno.com/examples/prisma_tutorial/ has section "Let's understand the key parameters", where arguments description written on Portugal instead of English

<img width="782" height="191" alt="image" src="https://github.com/user-attachments/assets/ac4d15fa-120b-47ce-9dc1-91098ca18704" />

this PR translates it to English