### PR TITLE
fix: An example `deno.json` file

### DIFF
--- a/runtime/fundamentals/configuration.md
+++ b/runtime/fundamentals/configuration.md
@@ -645,7 +645,7 @@ If you're ok with this risk, then this feature will be useful for you.
   },
   "permissions": {
     "default": {
-      "read": "./src/testdata/"
+      "read": ["./src/testdata/"]
     }
   },
   "lint": {


### PR DESCRIPTION
This pull request fixes a small mistake in the example of the permissions section. Neither the schema nor deno 2.5.0 allows a `string` to be passed to "read". It only allows a `boolean`, `string[]`, or `{ allow?: boolean | string[], deny?: boolean | string[] }`.