### PR TITLE
Update setup_your_environment.md

### DIFF
--- a/runtime/getting_started/setup_your_environment.md
+++ b/runtime/getting_started/setup_your_environment.md
@@ -83,17 +83,16 @@ may also need to set `single_file_support` to `false` for `ts_ls` to prevent it
 from running in `single file mode`. Here is an example of such a configuration:
 
 ```lua
-local nvim_lsp = require('lspconfig')
-nvim_lsp.denols.setup {
-  on_attach = on_attach,
-  root_dir = nvim_lsp.util.root_pattern("deno.json", "deno.jsonc"),
-}
+vim.lsp.config('denols', {
+    on_attach = on_attach,
+    root_markers = {"deno.json", "deno.jsonc"},
+})
 
-nvim_lsp.ts_ls.setup {
-  on_attach = on_attach,
-  root_dir = nvim_lsp.util.root_pattern("package.json"),
-  single_file_support = false
-}
+vim.lsp.config('ts_ls', {
+    on_attach = on_attach,
+    root_markers = {"package.json"},
+    single_file_support = false,
+})
 ```
 
 For Deno, the example above assumes a `deno.json` or `deno.jsonc` file exists at


### PR DESCRIPTION
Update the Neovim 0.6+ config to avoid using the `require('lspconfig')` "framework", which is deprecated and will be removed in nvim-lspconfig v3.0.0