### PR TITLE
make a prominent publish to jsr button, closes #2546

### DIFF
--- a/examples/videos/publishing_modules_with_jsr.md
+++ b/examples/videos/publishing_modules_with_jsr.md
@@ -70,6 +70,9 @@ export function sing(
 sing("la", 3);
 ```
 
+<a href="https://jsr.io/new" class="docs-cta jsr-cta">Publish to JSR
+<svg class="inline ml-1" viewBox="0 0 13 7" aria-hidden="true" height="20"><path d="M0,2h2v-2h7v1h4v4h-2v2h-7v-1h-4" fill="#083344"></path><g fill="#f7df1e"><path d="M1,3h1v1h1v-3h1v4h-3"></path><path d="M5,1h3v1h-2v1h2v3h-3v-1h2v-1h-2"></path><path d="M9,2h3v2h-1v-1h-1v3h-1"></path></g></svg></a>
+
 Now if we [head over to jsr.io, we can publish it](https://jsr.io/new). The
 first time I ever try to publish a package, JSR will ask me which scope I want
 to publish to. I can create that here.


### PR DESCRIPTION
Feedback suggested that the publish to jsr link was not obvious enough, have added a big yellow button
closes #2546 

Old: 
<img width="729" height="536" alt="image" src="https://github.com/user-attachments/assets/b1022bab-3b8f-46ea-a9b2-1721b0db88b4" />

New:
<img width="761" height="533" alt="image" src="https://github.com/user-attachments/assets/d440792c-8f4a-4be3-92f2-53db444f77e7" />
