### PR TITLE
Adjust anchor scrolltop on Services pages

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -975,6 +975,10 @@
     scroll-margin-top: var(--header-height);
   }
 
+  [data-services-page="true"] [id] {
+    scroll-margin-top: calc(var(--header-height) + var(--subnav-height));
+  }
+
   pre:has(code.highlight),
   pre.highlight:has(code) {
     @apply px-4 py-8 -mx-4 sm:mx-0 border-x-0 sm:border sm:px-8 rounded-none

--- a/styles.css
+++ b/styles.css
@@ -972,11 +972,7 @@
   }
 
   [id] {
-    scroll-margin-top: var(--header-height);
-  }
-
-  [data-services-page="true"] [id] {
-    scroll-margin-top: calc(var(--header-height) + var(--subnav-height));
+    scroll-margin-top: calc(var(--header-height) + var(--subnav-height) + 1rem);
   }
 
   pre:has(code.highlight),


### PR DESCRIPTION
Ensures that when linking directly to a specific heading, the page doesn't scroll too far and hide the heading behind the nav.