### PR TITLE
fix: use deno LTS in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/vscode/devcontainers/base:ubuntu
-COPY --from=denoland/deno:bin-2.0.4 /deno /usr/local/bin/deno
+COPY --from=denoland/deno:bin-2.4.5 /deno /usr/local/bin/deno
 
 EXPOSE 3000
 EXPOSE 8000


### PR DESCRIPTION
## Bug

The current deno version installed in the devcontainer does not support the current `deno.lock` version (5).

```
deno task serve
```
```
error: Failed reading lockfile at '/workspaces/deno-docs/deno.lock'

Caused by:
    Unsupported lockfile version '5'. Try upgrading Deno or recreating the lockfile
```
```
deno —version
```
```
deno 2.0.4 (stable, release, x86_64-unknown-linux-gnu)
v8 12.9.202.13-rusty
typescript 5.6.2
```

## Fix

Use the latest [LTS](https://docs.deno.com/runtime/fundamentals/stability_and_releases/#long-term-support-(lts)) deno version.

## Testing

Tested on Codespaces.

- post create command succeeds
  - `deno.lock` does not change with `deno install` here
- `deno task serve` runs and the doc site works
- `deno task test` succeeds