### PR TITLE
Fix framework typo on Vue.js Tutorial

### DIFF
--- a/examples/tutorials/vue.md
+++ b/examples/tutorials/vue.md
@@ -22,7 +22,7 @@ You can see a live version of the app on
 :::info Deploy your own
 
 Want to skip the tutorial and deploy the finished app right now? Click the
-button below to instantly deploy your own copy of the complete SvelteKit
+button below to instantly deploy your own copy of the complete Vue.js
 dinosaur app to Deno Deploy. You'll get a live, working application that you can
 customize and modify as you learn!
 

--- a/examples/tutorials/vue.md
+++ b/examples/tutorials/vue.md
@@ -22,8 +22,8 @@ You can see a live version of the app on
 :::info Deploy your own
 
 Want to skip the tutorial and deploy the finished app right now? Click the
-button below to instantly deploy your own copy of the complete Vue.js
-dinosaur app to Deno Deploy. You'll get a live, working application that you can
+button below to instantly deploy your own copy of the complete Vue.js dinosaur
+app to Deno Deploy. You'll get a live, working application that you can
 customize and modify as you learn!
 
 [![Deploy on Deno](https://deno.com/button)](https://console.deno.com/new?clone=https://github.com/denoland/tutorial-with-vue&mode=dynamic&entrypoint=api/main.ts&build=deno+task+build&install=deno+install)


### PR DESCRIPTION
In [Vue.js tutorial page](https://docs.deno.com/examples/vue_tutorial/) inside the "deploy your own" section, it has "SvelteKit" written instead of "Vue.js"