### PR TITLE
Rust FFI example: `no_mangle` is an `unsafe` attribute

### DIFF
--- a/runtime/fundamentals/ffi.md
+++ b/runtime/fundamentals/ffi.md
@@ -210,7 +210,7 @@ First, create a Rust library:
 
 ```rust
 // lib.rs
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn fibonacci(n: u32) -> u32 {
   if n <= 1 {
     return n;


### PR DESCRIPTION
As of [Rust 2024 Edition](https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html), the `#[no_mangle]` attribute [must be written as `#[unsafe(no_mangle)]`](https://doc.rust-lang.org/reference/abi.html#the-no_mangle-attribute). This PR updates the Rust FFI example accordingly.